### PR TITLE
rename constants to avoid conflicts

### DIFF
--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -26,10 +26,12 @@ def run_benchmark(benchmark_abs_path, query, engine, from_disk):
         print(cmd)
     # os.system(cmd)
     results =  subprocess.getoutput(cmd)
-    pattern = '^[0-9]+\.[0-9]+$'
+    pattern = '^Result: ([0-9]+\.[0-9]+)$'
     found = False
     for result in results.split("\n"):
-        if(re.match(pattern, result)):
+        result = re.match(pattern, result)
+        if(result):
+            result = result.group(1)
             # if previously is already found, this means your benchmark might run the query several times
             if found:
                 raise Exception("The benchmark is already run. Please make sure that DEFAULT_NRUNS in benchmark.hpp is 0 (which means the benchmark only runs 1 time) ")

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -1105,7 +1105,7 @@ timestamp_t CastTimestampUsToMs::Operation(timestamp_t input) {
 	if (!Timestamp::IsFinite(input)) {
 		return input;
 	}
-	timestamp_t cast_timestamp(Timestamp::GetEpochRounded(input, Interval::MICROS_PER_MSEC));
+	timestamp_t cast_timestamp(Timestamp::GetEpochRounded(input, Interval::DUCKDB_MICROS_PER_MSEC));
 	return cast_timestamp;
 }
 
@@ -1123,7 +1123,7 @@ timestamp_t CastTimestampUsToSec::Operation(timestamp_t input) {
 	if (!Timestamp::IsFinite(input)) {
 		return input;
 	}
-	timestamp_t cast_timestamp(Timestamp::GetEpochRounded(input, Interval::MICROS_PER_SEC));
+	timestamp_t cast_timestamp(Timestamp::GetEpochRounded(input, Interval::DUCKDB_MICROS_PER_SEC));
 	return cast_timestamp;
 }
 
@@ -1251,7 +1251,7 @@ bool TryCastToTimestampNS::Operation(date_t input, timestamp_ns_t &result, bool 
 	if (!Timestamp::IsFinite(result)) {
 		return true;
 	}
-	if (!TryMultiplyOperator::Operation(result.value, Interval::NANOS_PER_MICRO, result.value)) {
+	if (!TryMultiplyOperator::Operation(result.value, Interval::DUCKDB_NANOS_PER_MICRO, result.value)) {
 		return false;
 	}
 	return true;
@@ -1265,7 +1265,7 @@ bool TryCastToTimestampMS::Operation(date_t input, timestamp_t &result, bool str
 	if (!Timestamp::IsFinite(result)) {
 		return true;
 	}
-	result.value /= Interval::MICROS_PER_MSEC;
+	result.value /= Interval::DUCKDB_MICROS_PER_MSEC;
 	return true;
 }
 
@@ -1277,7 +1277,7 @@ bool TryCastToTimestampSec::Operation(date_t input, timestamp_t &result, bool st
 	if (!Timestamp::IsFinite(result)) {
 		return true;
 	}
-	result.value /= Interval::MICROS_PER_MSEC * Interval::MSECS_PER_SEC;
+	result.value /= Interval::DUCKDB_MICROS_PER_MSEC * Interval::DUCKDB_MSECS_PER_SEC;
 	return true;
 }
 

--- a/src/common/operator/string_cast.cpp
+++ b/src/common/operator/string_cast.cpp
@@ -209,18 +209,18 @@ string_t StringCastTZ::Operation(dtime_tz_t input, Vector &vector) {
 	++length;
 
 	auto ss = std::abs(offset);
-	const auto hh = ss / Interval::SECS_PER_HOUR;
+	const auto hh = ss / Interval::DUCKDB_SECS_PER_HOUR;
 
 	const auto hh_length = UnsafeNumericCast<idx_t>((hh < 100) ? 2 : NumericHelper::UnsignedLength(uint32_t(hh)));
 	length += hh_length;
 
-	ss %= Interval::SECS_PER_HOUR;
-	const auto mm = ss / Interval::SECS_PER_MINUTE;
+	ss %= Interval::DUCKDB_SECS_PER_HOUR;
+	const auto mm = ss / Interval::DUCKDB_SECS_PER_MINUTE;
 	if (mm) {
 		length += 3;
 	}
 
-	ss %= Interval::SECS_PER_MINUTE;
+	ss %= Interval::DUCKDB_SECS_PER_MINUTE;
 	if (ss) {
 		length += 3;
 	}

--- a/src/common/types/date.cpp
+++ b/src/common/types/date.cpp
@@ -422,16 +422,16 @@ int32_t Date::EpochDays(date_t date) {
 }
 
 date_t Date::EpochToDate(int64_t epoch) {
-	return date_t(UnsafeNumericCast<int32_t>(epoch / Interval::SECS_PER_DAY));
+	return date_t(UnsafeNumericCast<int32_t>(epoch / Interval::DUCKDB_SECS_PER_DAY));
 }
 
 int64_t Date::Epoch(date_t date) {
-	return ((int64_t)date.days) * Interval::SECS_PER_DAY;
+	return ((int64_t)date.days) * Interval::DUCKDB_SECS_PER_DAY;
 }
 
 int64_t Date::EpochNanoseconds(date_t date) {
 	int64_t result;
-	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(date.days, Interval::MICROS_PER_DAY * 1000,
+	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(date.days, Interval::DUCKDB_MICROS_PER_DAY * 1000,
 	                                                               result)) {
 		throw ConversionException("Could not convert DATE (%s) to nanoseconds", Date::ToString(date));
 	}
@@ -440,7 +440,7 @@ int64_t Date::EpochNanoseconds(date_t date) {
 
 int64_t Date::EpochMicroseconds(date_t date) {
 	int64_t result;
-	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(date.days, Interval::MICROS_PER_DAY, result)) {
+	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(date.days, Interval::DUCKDB_MICROS_PER_DAY, result)) {
 		throw ConversionException("Could not convert DATE (%s) to microseconds", Date::ToString(date));
 	}
 	return result;
@@ -448,7 +448,7 @@ int64_t Date::EpochMicroseconds(date_t date) {
 
 int64_t Date::EpochMilliseconds(date_t date) {
 	int64_t result;
-	const auto MILLIS_PER_DAY = Interval::MICROS_PER_DAY / Interval::MICROS_PER_MSEC;
+	const auto MILLIS_PER_DAY = Interval::DUCKDB_MICROS_PER_DAY / Interval::DUCKDB_MICROS_PER_MSEC;
 	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(date.days, MILLIS_PER_DAY, result)) {
 		throw ConversionException("Could not convert DATE (%s) to milliseconds", Date::ToString(date));
 	}

--- a/src/common/types/interval.cpp
+++ b/src/common/types/interval.cpp
@@ -32,9 +32,9 @@ void IntervalTryAddition(T &target, int64_t input, int64_t multiplier, int64_t f
 		throw OutOfRangeException("interval value is out of range");
 	}
 	if (fraction) {
-		//	Add in (fraction * multiplier) / MICROS_PER_SEC
+		//	Add in (fraction * multiplier) / DUCKDB_MICROS_PER_SEC
 		//	This is always in range
-		addition = (fraction * multiplier) / Interval::MICROS_PER_SEC;
+		addition = (fraction * multiplier) / Interval::DUCKDB_MICROS_PER_SEC;
 		addition_base = Cast::Operation<int64_t, T>(addition);
 		if (!TryAddOperator::Operation<T, T, T>(target, addition_base, target)) {
 			throw OutOfRangeException("interval fraction is out of range");
@@ -170,7 +170,7 @@ interval_parse_identifier:
 
 	// Special case SS[.FFFFFF] - implied SECONDS/MICROSECONDS
 	if (specifier_str.empty() && !found_any) {
-		IntervalTryAddition<int64_t>(result.micros, number, MICROS_PER_SEC);
+		IntervalTryAddition<int64_t>(result.micros, number, DUCKDB_MICROS_PER_SEC);
 		IntervalTryAddition<int64_t>(result.micros, fraction, 1);
 		found_any = true;
 		// parse any trailing whitespace
@@ -193,55 +193,55 @@ interval_parse_identifier:
 	// add the specifier to the interval
 	switch (specifier) {
 	case DatePartSpecifier::MILLENNIUM:
-		IntervalTryAddition<int32_t>(result.months, number, MONTHS_PER_MILLENIUM, fraction);
+		IntervalTryAddition<int32_t>(result.months, number, DUCKDB_MONTHS_PER_MILLENIUM, fraction);
 		break;
 	case DatePartSpecifier::CENTURY:
-		IntervalTryAddition<int32_t>(result.months, number, MONTHS_PER_CENTURY, fraction);
+		IntervalTryAddition<int32_t>(result.months, number, DUCKDB_MONTHS_PER_CENTURY, fraction);
 		break;
 	case DatePartSpecifier::DECADE:
-		IntervalTryAddition<int32_t>(result.months, number, MONTHS_PER_DECADE, fraction);
+		IntervalTryAddition<int32_t>(result.months, number, DUCKDB_MONTHS_PER_DECADE, fraction);
 		break;
 	case DatePartSpecifier::YEAR:
-		IntervalTryAddition<int32_t>(result.months, number, MONTHS_PER_YEAR, fraction);
+		IntervalTryAddition<int32_t>(result.months, number, DUCKDB_MONTHS_PER_YEAR, fraction);
 		break;
 	case DatePartSpecifier::QUARTER:
-		IntervalTryAddition<int32_t>(result.months, number, MONTHS_PER_QUARTER, fraction);
+		IntervalTryAddition<int32_t>(result.months, number, DUCKDB_MONTHS_PER_QUARTER, fraction);
 		// Reduce to fraction of a month
-		fraction *= MONTHS_PER_QUARTER;
-		fraction %= MICROS_PER_SEC;
-		IntervalTryAddition<int32_t>(result.days, 0, DAYS_PER_MONTH, fraction);
+		fraction *= DUCKDB_MONTHS_PER_QUARTER;
+		fraction %= DUCKDB_MICROS_PER_SEC;
+		IntervalTryAddition<int32_t>(result.days, 0, DUCKDB_DAYS_PER_MONTH, fraction);
 		break;
 	case DatePartSpecifier::MONTH:
 		IntervalTryAddition<int32_t>(result.months, number, 1);
-		IntervalTryAddition<int32_t>(result.days, 0, DAYS_PER_MONTH, fraction);
+		IntervalTryAddition<int32_t>(result.days, 0, DUCKDB_DAYS_PER_MONTH, fraction);
 		break;
 	case DatePartSpecifier::DAY:
 		IntervalTryAddition<int32_t>(result.days, number, 1);
-		IntervalTryAddition<int64_t>(result.micros, 0, MICROS_PER_DAY, fraction);
+		IntervalTryAddition<int64_t>(result.micros, 0, DUCKDB_MICROS_PER_DAY, fraction);
 		break;
 	case DatePartSpecifier::WEEK:
-		IntervalTryAddition<int32_t>(result.days, number, DAYS_PER_WEEK, fraction);
+		IntervalTryAddition<int32_t>(result.days, number, DUCKDB_DAYS_PER_WEEK, fraction);
 		// Reduce to fraction of a day
-		fraction *= DAYS_PER_WEEK;
-		fraction %= MICROS_PER_SEC;
-		IntervalTryAddition<int64_t>(result.micros, 0, MICROS_PER_DAY, fraction);
+		fraction *= DUCKDB_DAYS_PER_WEEK;
+		fraction %= DUCKDB_MICROS_PER_SEC;
+		IntervalTryAddition<int64_t>(result.micros, 0, DUCKDB_MICROS_PER_DAY, fraction);
 		break;
 	case DatePartSpecifier::MICROSECONDS:
 		// Round the fraction
-		number += (fraction * 2) / MICROS_PER_SEC;
+		number += (fraction * 2) / DUCKDB_MICROS_PER_SEC;
 		IntervalTryAddition<int64_t>(result.micros, number, 1);
 		break;
 	case DatePartSpecifier::MILLISECONDS:
-		IntervalTryAddition<int64_t>(result.micros, number, MICROS_PER_MSEC, fraction);
+		IntervalTryAddition<int64_t>(result.micros, number, DUCKDB_MICROS_PER_MSEC, fraction);
 		break;
 	case DatePartSpecifier::SECOND:
-		IntervalTryAddition<int64_t>(result.micros, number, MICROS_PER_SEC, fraction);
+		IntervalTryAddition<int64_t>(result.micros, number, DUCKDB_MICROS_PER_SEC, fraction);
 		break;
 	case DatePartSpecifier::MINUTE:
-		IntervalTryAddition<int64_t>(result.micros, number, MICROS_PER_MINUTE, fraction);
+		IntervalTryAddition<int64_t>(result.micros, number, DUCKDB_MICROS_PER_MINUTE, fraction);
 		break;
 	case DatePartSpecifier::HOUR:
-		IntervalTryAddition<int64_t>(result.micros, number, MICROS_PER_HOUR, fraction);
+		IntervalTryAddition<int64_t>(result.micros, number, DUCKDB_MICROS_PER_HOUR, fraction);
 		break;
 	default:
 		HandleCastError::AssignError(
@@ -297,10 +297,10 @@ string Interval::ToString(const interval_t &interval) {
 
 int64_t Interval::GetMilli(const interval_t &val) {
 	int64_t milli_month, milli_day, milli;
-	if (!TryMultiplyOperator::Operation((int64_t)val.months, Interval::MICROS_PER_MONTH / 1000, milli_month)) {
+	if (!TryMultiplyOperator::Operation((int64_t)val.months, Interval::DUCKDB_MICROS_PER_MONTH / 1000, milli_month)) {
 		throw ConversionException("Could not convert Interval to Milliseconds");
 	}
-	if (!TryMultiplyOperator::Operation((int64_t)val.days, Interval::MICROS_PER_DAY / 1000, milli_day)) {
+	if (!TryMultiplyOperator::Operation((int64_t)val.days, Interval::DUCKDB_MICROS_PER_DAY / 1000, milli_day)) {
 		throw ConversionException("Could not convert Interval to Milliseconds");
 	}
 	milli = val.micros / 1000;
@@ -316,10 +316,10 @@ int64_t Interval::GetMilli(const interval_t &val) {
 int64_t Interval::GetMicro(const interval_t &val) {
 	int64_t micro_month, micro_day, micro_total;
 	micro_total = val.micros;
-	if (!TryMultiplyOperator::Operation((int64_t)val.months, MICROS_PER_MONTH, micro_month)) {
+	if (!TryMultiplyOperator::Operation((int64_t)val.months, DUCKDB_MICROS_PER_MONTH, micro_month)) {
 		throw ConversionException("Could not convert Month to Microseconds");
 	}
-	if (!TryMultiplyOperator::Operation((int64_t)val.days, MICROS_PER_DAY, micro_day)) {
+	if (!TryMultiplyOperator::Operation((int64_t)val.days, DUCKDB_MICROS_PER_DAY, micro_day)) {
 		throw ConversionException("Could not convert Day to Microseconds");
 	}
 	if (!TryAddOperator::Operation<int64_t, int64_t, int64_t>(micro_total, micro_month, micro_total)) {
@@ -335,7 +335,7 @@ int64_t Interval::GetMicro(const interval_t &val) {
 int64_t Interval::GetNanoseconds(const interval_t &val) {
 	int64_t nano;
 	const auto micro_total = GetMicro(val);
-	if (!TryMultiplyOperator::Operation(micro_total, NANOS_PER_MICRO, nano)) {
+	if (!TryMultiplyOperator::Operation(micro_total, DUCKDB_NANOS_PER_MICRO, nano)) {
 		throw ConversionException("Could not convert Interval to Nanoseconds");
 	}
 
@@ -385,19 +385,19 @@ interval_t Interval::GetAge(timestamp_t timestamp_1, timestamp_t timestamp_2) {
 	}
 	// now propagate any negative field into the next higher field
 	while (micros_diff < 0) {
-		micros_diff += MICROS_PER_SEC;
+		micros_diff += DUCKDB_MICROS_PER_SEC;
 		sec_diff--;
 	}
 	while (sec_diff < 0) {
-		sec_diff += SECS_PER_MINUTE;
+		sec_diff += DUCKDB_SECS_PER_MINUTE;
 		min_diff--;
 	}
 	while (min_diff < 0) {
-		min_diff += MINS_PER_HOUR;
+		min_diff += DUCKDB_MINS_PER_HOUR;
 		hour_diff--;
 	}
 	while (hour_diff < 0) {
-		hour_diff += HOURS_PER_DAY;
+		hour_diff += DUCKDB_HOURS_PER_DAY;
 		day_diff--;
 	}
 	while (day_diff < 0) {
@@ -410,7 +410,7 @@ interval_t Interval::GetAge(timestamp_t timestamp_1, timestamp_t timestamp_2) {
 		}
 	}
 	while (month_diff < 0) {
-		month_diff += MONTHS_PER_YEAR;
+		month_diff += DUCKDB_MONTHS_PER_YEAR;
 		year_diff--;
 	}
 
@@ -425,7 +425,7 @@ interval_t Interval::GetAge(timestamp_t timestamp_1, timestamp_t timestamp_2) {
 		micros_diff = -micros_diff;
 	}
 	interval_t interval;
-	interval.months = year_diff * MONTHS_PER_YEAR + month_diff;
+	interval.months = year_diff * DUCKDB_MONTHS_PER_YEAR + month_diff;
 	interval.days = day_diff;
 	interval.micros = Time::FromTime(hour_diff, min_diff, sec_diff, micros_diff).micros;
 
@@ -448,8 +448,8 @@ interval_t Interval::GetDifference(timestamp_t timestamp_1, timestamp_t timestam
 interval_t Interval::FromMicro(int64_t delta_us) {
 	interval_t result;
 	result.months = 0;
-	result.days = UnsafeNumericCast<int32_t>(delta_us / Interval::MICROS_PER_DAY);
-	result.micros = delta_us % Interval::MICROS_PER_DAY;
+	result.days = UnsafeNumericCast<int32_t>(delta_us / Interval::DUCKDB_MICROS_PER_DAY);
+	result.micros = delta_us % Interval::DUCKDB_MICROS_PER_DAY;
 
 	return result;
 }
@@ -469,15 +469,15 @@ date_t Interval::Add(date_t left, interval_t right) {
 	if (right.months != 0) {
 		int32_t year, month, day;
 		Date::Convert(left, year, month, day);
-		int32_t year_diff = right.months / Interval::MONTHS_PER_YEAR;
+		int32_t year_diff = right.months / Interval::DUCKDB_MONTHS_PER_YEAR;
 		year += year_diff;
-		month += right.months - year_diff * Interval::MONTHS_PER_YEAR;
-		if (month > Interval::MONTHS_PER_YEAR) {
+		month += right.months - year_diff * Interval::DUCKDB_MONTHS_PER_YEAR;
+		if (month > Interval::DUCKDB_MONTHS_PER_YEAR) {
 			year++;
-			month -= Interval::MONTHS_PER_YEAR;
+			month -= Interval::DUCKDB_MONTHS_PER_YEAR;
 		} else if (month <= 0) {
 			year--;
-			month += Interval::MONTHS_PER_YEAR;
+			month += Interval::DUCKDB_MONTHS_PER_YEAR;
 		}
 		day = MinValue<int32_t>(day, Date::MonthDays(year, month));
 		result = Date::FromDate(year, month, day);
@@ -490,7 +490,7 @@ date_t Interval::Add(date_t left, interval_t right) {
 		}
 	}
 	if (right.micros != 0) {
-		if (!TryAddOperator::Operation(result.days, int32_t(right.micros / Interval::MICROS_PER_DAY), result.days)) {
+		if (!TryAddOperator::Operation(result.days, int32_t(right.micros / Interval::DUCKDB_MICROS_PER_DAY), result.days)) {
 			throw OutOfRangeException("Date out of range");
 		}
 	}
@@ -501,13 +501,13 @@ date_t Interval::Add(date_t left, interval_t right) {
 }
 
 dtime_t Interval::Add(dtime_t left, interval_t right, date_t &date) {
-	int64_t diff = right.micros - ((right.micros / Interval::MICROS_PER_DAY) * Interval::MICROS_PER_DAY);
+	int64_t diff = right.micros - ((right.micros / Interval::DUCKDB_MICROS_PER_DAY) * Interval::DUCKDB_MICROS_PER_DAY);
 	left += diff;
-	if (left.micros >= Interval::MICROS_PER_DAY) {
-		left.micros -= Interval::MICROS_PER_DAY;
+	if (left.micros >= Interval::DUCKDB_MICROS_PER_DAY) {
+		left.micros -= Interval::DUCKDB_MICROS_PER_DAY;
 		date.days++;
 	} else if (left.micros < 0) {
-		left.micros += Interval::MICROS_PER_DAY;
+		left.micros += Interval::DUCKDB_MICROS_PER_DAY;
 		date.days--;
 	}
 	return left;

--- a/src/common/types/time.cpp
+++ b/src/common/types/time.cpp
@@ -105,7 +105,7 @@ bool Time::TryConvertInternal(const char *buf, idx_t len, idx_t &pos, dtime_t &r
 		int32_t mult = 100000;
 		if (nanos) {
 			// do we expect nanoseconds?
-			mult *= Interval::NANOS_PER_MICRO;
+			mult *= Interval::DUCKDB_NANOS_PER_MICRO;
 		}
 		for (; pos < len && StringUtil::CharacterIsDigit(buf[pos]); pos++, mult /= 10) {
 			if (mult > 0) {
@@ -113,8 +113,8 @@ bool Time::TryConvertInternal(const char *buf, idx_t len, idx_t &pos, dtime_t &r
 			}
 		}
 		if (nanos) {
-			*nanos = UnsafeNumericCast<int32_t>(micros % Interval::NANOS_PER_MICRO);
-			micros /= Interval::NANOS_PER_MICRO;
+			*nanos = UnsafeNumericCast<int32_t>(micros % Interval::DUCKDB_NANOS_PER_MICRO);
+			micros /= Interval::DUCKDB_NANOS_PER_MICRO;
 		}
 	}
 
@@ -155,7 +155,7 @@ bool Time::TryConvertTime(const char *buf, idx_t len, idx_t &pos, dtime_t &resul
 		}
 		return false;
 	}
-	return result.micros <= Interval::MICROS_PER_DAY;
+	return result.micros <= Interval::DUCKDB_MICROS_PER_DAY;
 }
 
 bool Time::TryConvertTimeTZ(const char *buf, idx_t len, idx_t &pos, dtime_tz_t &result, bool &has_offset, bool strict,
@@ -191,7 +191,7 @@ bool Time::TryConvertTimeTZ(const char *buf, idx_t len, idx_t &pos, dtime_tz_t &
 	}
 
 	//	Offsets are in seconds in the open interval (-16:00:00, +16:00:00)
-	int32_t offset = ((hh * Interval::MINS_PER_HOUR) + mm) * Interval::SECS_PER_MINUTE;
+	int32_t offset = ((hh * Interval::DUCKDB_MINS_PER_HOUR) + mm) * Interval::DUCKDB_SECS_PER_MINUTE;
 
 	//	Check for trailing seconds.
 	//	(PG claims they don't support this but they do...)
@@ -227,7 +227,7 @@ bool Time::TryConvertTimeTZ(const char *buf, idx_t len, idx_t &pos, dtime_tz_t &
 
 dtime_t Time::NormalizeTimeTZ(dtime_tz_t timetz) {
 	date_t date(0);
-	return Interval::Add(timetz.time(), {0, 0, -timetz.offset() * Interval::MICROS_PER_SEC}, date);
+	return Interval::Add(timetz.time(), {0, 0, -timetz.offset() * Interval::DUCKDB_MICROS_PER_SEC}, date);
 }
 
 string Time::ConversionError(const string &str) {
@@ -265,7 +265,7 @@ string Time::ToString(dtime_t time) {
 }
 
 string Time::ToUTCOffset(int hour_offset, int minute_offset) {
-	dtime_t time((hour_offset * Interval::MINS_PER_HOUR + minute_offset) * Interval::MICROS_PER_MINUTE);
+	dtime_t time((hour_offset * Interval::DUCKDB_MINS_PER_HOUR + minute_offset) * Interval::DUCKDB_MICROS_PER_MINUTE);
 
 	char buffer[1 + 2 + 1 + 2];
 	idx_t length = 0;
@@ -289,18 +289,18 @@ string Time::ToUTCOffset(int hour_offset, int minute_offset) {
 dtime_t Time::FromTime(int32_t hour, int32_t minute, int32_t second, int32_t microseconds) {
 	int64_t result;
 	result = hour;                                             // hours
-	result = result * Interval::MINS_PER_HOUR + minute;        // hours -> minutes
-	result = result * Interval::SECS_PER_MINUTE + second;      // minutes -> seconds
-	result = result * Interval::MICROS_PER_SEC + microseconds; // seconds -> microseconds
+	result = result * Interval::DUCKDB_MINS_PER_HOUR + minute;        // hours -> minutes
+	result = result * Interval::DUCKDB_SECS_PER_MINUTE + second;      // minutes -> seconds
+	result = result * Interval::DUCKDB_MICROS_PER_SEC + microseconds; // seconds -> microseconds
 	return dtime_t(result);
 }
 
 int64_t Time::ToNanoTime(int32_t hour, int32_t minute, int32_t second, int32_t nanoseconds) {
 	int64_t result;
 	result = hour;                                           // hours
-	result = result * Interval::MINS_PER_HOUR + minute;      // hours -> minutes
-	result = result * Interval::SECS_PER_MINUTE + second;    // minutes -> seconds
-	result = result * Interval::NANOS_PER_SEC + nanoseconds; // seconds -> nanoseconds
+	result = result * Interval::DUCKDB_MINS_PER_HOUR + minute;      // hours -> minutes
+	result = result * Interval::DUCKDB_SECS_PER_MINUTE + second;    // minutes -> seconds
+	result = result * Interval::DUCKDB_NANOS_PER_SEC + nanoseconds; // seconds -> nanoseconds
 	return result;
 }
 
@@ -322,26 +322,26 @@ bool Time::IsValidTime(int32_t hour, int32_t minute, int32_t second, int32_t mic
 
 void Time::Convert(dtime_t dtime, int32_t &hour, int32_t &min, int32_t &sec, int32_t &micros) {
 	int64_t time = dtime.micros;
-	hour = int32_t(time / Interval::MICROS_PER_HOUR);
-	time -= int64_t(hour) * Interval::MICROS_PER_HOUR;
-	min = int32_t(time / Interval::MICROS_PER_MINUTE);
-	time -= int64_t(min) * Interval::MICROS_PER_MINUTE;
-	sec = int32_t(time / Interval::MICROS_PER_SEC);
-	time -= int64_t(sec) * Interval::MICROS_PER_SEC;
+	hour = int32_t(time / Interval::DUCKDB_MICROS_PER_HOUR);
+	time -= int64_t(hour) * Interval::DUCKDB_MICROS_PER_HOUR;
+	min = int32_t(time / Interval::DUCKDB_MICROS_PER_MINUTE);
+	time -= int64_t(min) * Interval::DUCKDB_MICROS_PER_MINUTE;
+	sec = int32_t(time / Interval::DUCKDB_MICROS_PER_SEC);
+	time -= int64_t(sec) * Interval::DUCKDB_MICROS_PER_SEC;
 	micros = int32_t(time);
 	D_ASSERT(Time::IsValidTime(hour, min, sec, micros));
 }
 
 dtime_t Time::FromTimeMs(int64_t time_ms) {
 	int64_t result;
-	if (!TryMultiplyOperator::Operation(time_ms, Interval::MICROS_PER_MSEC, result)) {
+	if (!TryMultiplyOperator::Operation(time_ms, Interval::DUCKDB_MICROS_PER_MSEC, result)) {
 		throw ConversionException("Could not convert Time(MS) to Time(US)");
 	}
 	return dtime_t(result);
 }
 
 dtime_t Time::FromTimeNs(int64_t time_ns) {
-	return dtime_t(time_ns / Interval::NANOS_PER_MICRO);
+	return dtime_t(time_ns / Interval::DUCKDB_NANOS_PER_MICRO);
 }
 
 } // namespace duckdb

--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -87,7 +87,7 @@ bool Timestamp::TryConvertTimestampTZ(const char *str, idx_t len, timestamp_t &r
 		return false;
 	}
 	//	We parsed an interval, so make sure it is in range.
-	if (time.micros > Interval::MICROS_PER_DAY) {
+	if (time.micros > Interval::DUCKDB_MICROS_PER_DAY) {
 		return false;
 	}
 	pos += time_pos;
@@ -101,7 +101,7 @@ bool Timestamp::TryConvertTimestampTZ(const char *str, idx_t len, timestamp_t &r
 			pos++;
 			has_offset = true;
 		} else if (Timestamp::TryParseUTCOffset(str, pos, len, hour_offset, minute_offset)) {
-			const int64_t delta = hour_offset * Interval::MICROS_PER_HOUR + minute_offset * Interval::MICROS_PER_MINUTE;
+			const int64_t delta = hour_offset * Interval::DUCKDB_MICROS_PER_HOUR + minute_offset * Interval::DUCKDB_MICROS_PER_MINUTE;
 			if (!TrySubtractOperator::Operation(result.value, delta, result.value)) {
 				return false;
 			}
@@ -163,7 +163,7 @@ bool Timestamp::TryFromTimestampNanos(timestamp_t input, int32_t nanos, timestam
 		return true;
 	}
 	// Scale to ns
-	if (!TryMultiplyOperator::Operation(input.value, Interval::NANOS_PER_MICRO, result.value)) {
+	if (!TryMultiplyOperator::Operation(input.value, Interval::DUCKDB_NANOS_PER_MICRO, result.value)) {
 		return false;
 	}
 
@@ -285,7 +285,7 @@ date_t Timestamp::GetDate(timestamp_t timestamp) {
 	} else if (DUCKDB_UNLIKELY(timestamp == timestamp_t::ninfinity())) {
 		return date_t::ninfinity();
 	}
-	return date_t(UnsafeNumericCast<int32_t>((timestamp.value + (timestamp.value < 0)) / Interval::MICROS_PER_DAY -
+	return date_t(UnsafeNumericCast<int32_t>((timestamp.value + (timestamp.value < 0)) / Interval::DUCKDB_MICROS_PER_DAY -
 	                                         (timestamp.value < 0)));
 }
 
@@ -294,11 +294,11 @@ dtime_t Timestamp::GetTime(timestamp_t timestamp) {
 		throw ConversionException("Can't get TIME of infinite TIMESTAMP");
 	}
 	date_t date = Timestamp::GetDate(timestamp);
-	return dtime_t(timestamp.value - (int64_t(date.days) * int64_t(Interval::MICROS_PER_DAY)));
+	return dtime_t(timestamp.value - (int64_t(date.days) * int64_t(Interval::DUCKDB_MICROS_PER_DAY)));
 }
 
 bool Timestamp::TryFromDatetime(date_t date, dtime_t time, timestamp_t &result) {
-	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(date.days, Interval::MICROS_PER_DAY, result.value)) {
+	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(date.days, Interval::DUCKDB_MICROS_PER_DAY, result.value)) {
 		return false;
 	}
 	if (!TryAddOperator::Operation<int64_t, int64_t, int64_t>(result.value, time.micros, result.value)) {
@@ -312,7 +312,7 @@ bool Timestamp::TryFromDatetime(date_t date, dtime_tz_t timetz, timestamp_t &res
 		return false;
 	}
 	// Offset is in seconds
-	const auto offset = int64_t(timetz.offset() * Interval::MICROS_PER_SEC);
+	const auto offset = int64_t(timetz.offset() * Interval::DUCKDB_MICROS_PER_SEC);
 	if (!TryAddOperator::Operation(result.value, -offset, result.value)) {
 		return false;
 	}
@@ -330,7 +330,7 @@ timestamp_t Timestamp::FromDatetime(date_t date, dtime_t time) {
 void Timestamp::Convert(timestamp_t timestamp, date_t &out_date, dtime_t &out_time) {
 	out_date = GetDate(timestamp);
 	int64_t days_micros;
-	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(out_date.days, Interval::MICROS_PER_DAY,
+	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(out_date.days, Interval::DUCKDB_MICROS_PER_DAY,
 	                                                               days_micros)) {
 		throw ConversionException("Date out of range in timestamp conversion");
 	}
@@ -339,16 +339,16 @@ void Timestamp::Convert(timestamp_t timestamp, date_t &out_date, dtime_t &out_ti
 }
 
 void Timestamp::Convert(timestamp_ns_t input, date_t &out_date, dtime_t &out_time, int32_t &out_nanos) {
-	timestamp_t ms(input.value / Interval::NANOS_PER_MICRO);
+	timestamp_t ms(input.value / Interval::DUCKDB_NANOS_PER_MICRO);
 	out_date = Timestamp::GetDate(ms);
 	int64_t days_nanos;
-	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(out_date.days, Interval::NANOS_PER_DAY,
+	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(out_date.days, Interval::DUCKDB_NANOS_PER_DAY,
 	                                                               days_nanos)) {
 		throw ConversionException("Date out of range in timestamp_ns conversion");
 	}
 
-	out_time = dtime_t((input.value - days_nanos) / Interval::NANOS_PER_MICRO);
-	out_nanos = UnsafeNumericCast<int32_t>((input.value - days_nanos) % Interval::NANOS_PER_MICRO);
+	out_time = dtime_t((input.value - days_nanos) / Interval::DUCKDB_NANOS_PER_MICRO);
+	out_nanos = UnsafeNumericCast<int32_t>((input.value - days_nanos) % Interval::DUCKDB_NANOS_PER_MICRO);
 }
 
 timestamp_t Timestamp::GetCurrentTimestamp() {
@@ -359,7 +359,7 @@ timestamp_t Timestamp::GetCurrentTimestamp() {
 
 timestamp_t Timestamp::FromEpochSecondsPossiblyInfinite(int64_t sec) {
 	int64_t result;
-	if (!TryMultiplyOperator::Operation(sec, Interval::MICROS_PER_SEC, result)) {
+	if (!TryMultiplyOperator::Operation(sec, Interval::DUCKDB_MICROS_PER_SEC, result)) {
 		throw ConversionException("Could not convert Timestamp(S) to Timestamp(US)");
 	}
 	return timestamp_t(result);
@@ -372,7 +372,7 @@ timestamp_t Timestamp::FromEpochSeconds(int64_t sec) {
 
 timestamp_t Timestamp::FromEpochMsPossiblyInfinite(int64_t ms) {
 	int64_t result;
-	if (!TryMultiplyOperator::Operation(ms, Interval::MICROS_PER_MSEC, result)) {
+	if (!TryMultiplyOperator::Operation(ms, Interval::DUCKDB_MICROS_PER_MSEC, result)) {
 		throw ConversionException("Could not convert Timestamp(MS) to Timestamp(US)");
 	}
 	return timestamp_t(result);
@@ -388,7 +388,7 @@ timestamp_t Timestamp::FromEpochMicroSeconds(int64_t micros) {
 }
 
 timestamp_t Timestamp::FromEpochNanoSecondsPossiblyInfinite(int64_t ns) {
-	return timestamp_t(ns / Interval::NANOS_PER_MICRO);
+	return timestamp_t(ns / Interval::DUCKDB_NANOS_PER_MICRO);
 }
 
 timestamp_t Timestamp::FromEpochNanoSeconds(int64_t ns) {
@@ -399,7 +399,7 @@ timestamp_t Timestamp::FromEpochNanoSeconds(int64_t ns) {
 timestamp_ns_t Timestamp::TimestampNsFromEpochMillis(int64_t millis) {
 	D_ASSERT(Timestamp::IsFinite(timestamp_t(millis)));
 	timestamp_ns_t result;
-	if (!TryMultiplyOperator::Operation(millis, Interval::NANOS_PER_MICRO, result.value)) {
+	if (!TryMultiplyOperator::Operation(millis, Interval::DUCKDB_NANOS_PER_MICRO, result.value)) {
 		throw ConversionException("Could not convert Timestamp(US) to Timestamp(NS)");
 	}
 	return result;
@@ -408,7 +408,7 @@ timestamp_ns_t Timestamp::TimestampNsFromEpochMillis(int64_t millis) {
 timestamp_ns_t Timestamp::TimestampNsFromEpochMicros(int64_t micros) {
 	D_ASSERT(Timestamp::IsFinite(timestamp_t(micros)));
 	timestamp_ns_t result;
-	if (!TryMultiplyOperator::Operation(micros, Interval::NANOS_PER_MSEC, result.value)) {
+	if (!TryMultiplyOperator::Operation(micros, Interval::DUCKDB_NANOS_PER_MSEC, result.value)) {
 		throw ConversionException("Could not convert Timestamp(MS) to Timestamp(NS)");
 	}
 	return result;
@@ -416,12 +416,12 @@ timestamp_ns_t Timestamp::TimestampNsFromEpochMicros(int64_t micros) {
 
 int64_t Timestamp::GetEpochSeconds(timestamp_t timestamp) {
 	D_ASSERT(Timestamp::IsFinite(timestamp));
-	return timestamp.value / Interval::MICROS_PER_SEC;
+	return timestamp.value / Interval::DUCKDB_MICROS_PER_SEC;
 }
 
 int64_t Timestamp::GetEpochMs(timestamp_t timestamp) {
 	D_ASSERT(Timestamp::IsFinite(timestamp));
-	return timestamp.value / Interval::MICROS_PER_MSEC;
+	return timestamp.value / Interval::DUCKDB_MICROS_PER_MSEC;
 }
 
 int64_t Timestamp::GetEpochMicroSeconds(timestamp_t timestamp) {
@@ -430,7 +430,7 @@ int64_t Timestamp::GetEpochMicroSeconds(timestamp_t timestamp) {
 
 bool Timestamp::TryGetEpochNanoSeconds(timestamp_t timestamp, int64_t &result) {
 	D_ASSERT(Timestamp::IsFinite(timestamp));
-	if (!TryMultiplyOperator::Operation(timestamp.value, Interval::NANOS_PER_MICRO, result)) {
+	if (!TryMultiplyOperator::Operation(timestamp.value, Interval::DUCKDB_NANOS_PER_MICRO, result)) {
 		return false;
 	}
 	return true;
@@ -462,7 +462,7 @@ int64_t Timestamp::GetEpochRounded(timestamp_t input, int64_t power_of_ten) {
 
 double Timestamp::GetJulianDay(timestamp_t timestamp) {
 	double result = double(Timestamp::GetTime(timestamp).micros);
-	result /= Interval::MICROS_PER_DAY;
+	result /= Interval::DUCKDB_MICROS_PER_DAY;
 	result += double(Date::ExtractJulianDay(Timestamp::GetDate(timestamp)));
 	return result;
 }

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -243,8 +243,8 @@ Value Value::MinimumValue(const LogicalType &type) {
 	case LogicalTypeId::TIMESTAMP_NS: {
 		// Clear the fractional day.
 		auto min_ns = NumericLimits<int64_t>::Minimum();
-		min_ns /= Interval::NANOS_PER_DAY;
-		min_ns *= Interval::NANOS_PER_DAY;
+		min_ns /= Interval::DUCKDB_NANOS_PER_DAY;
+		min_ns *= Interval::DUCKDB_NANOS_PER_DAY;
 		return Value::TIMESTAMPNS(timestamp_t(min_ns));
 	}
 	case LogicalTypeId::TIME_TZ:
@@ -316,7 +316,7 @@ Value Value::MaximumValue(const LogicalType &type) {
 		return Value::DATE(Date::FromDate(Date::DATE_MAX_YEAR, Date::DATE_MAX_MONTH, Date::DATE_MAX_DAY));
 	case LogicalTypeId::TIME:
 		//	24:00:00 according to PG
-		return Value::TIME(dtime_t(Interval::MICROS_PER_DAY));
+		return Value::TIME(dtime_t(Interval::DUCKDB_MICROS_PER_DAY));
 	case LogicalTypeId::TIMESTAMP:
 		return Value::TIMESTAMP(timestamp_t(NumericLimits<int64_t>::Maximum() - 1));
 	case LogicalTypeId::TIMESTAMP_MS: {
@@ -333,7 +333,7 @@ Value Value::MaximumValue(const LogicalType &type) {
 	}
 	case LogicalTypeId::TIME_TZ:
 		//	"24:00:00-1559" from the PG docs but actually "24:00:00-15:59:59"
-		return Value::TIMETZ(dtime_tz_t(dtime_t(Interval::MICROS_PER_DAY), dtime_tz_t::MIN_OFFSET));
+		return Value::TIMETZ(dtime_tz_t(dtime_t(Interval::DUCKDB_MICROS_PER_DAY), dtime_tz_t::MIN_OFFSET));
 	case LogicalTypeId::TIMESTAMP_TZ:
 		return MaximumValue(LogicalType::TIMESTAMP);
 	case LogicalTypeId::FLOAT:

--- a/src/core_functions/scalar/date/date_diff.cpp
+++ b/src/core_functions/scalar/date/date_diff.cpp
@@ -83,8 +83,8 @@ struct DateDiff {
 			int32_t end_year, end_month, end_day;
 			Date::Convert(enddate, end_year, end_month, end_day);
 
-			return (end_year * 12 + end_month - 1) / Interval::MONTHS_PER_QUARTER -
-			       (start_year * 12 + start_month - 1) / Interval::MONTHS_PER_QUARTER;
+			return (end_year * 12 + end_month - 1) / Interval::DUCKDB_MONTHS_PER_QUARTER -
+			       (start_year * 12 + start_month - 1) / Interval::DUCKDB_MONTHS_PER_QUARTER;
 		}
 	};
 
@@ -92,7 +92,7 @@ struct DateDiff {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA startdate, TB enddate) {
 			//	Weeks do not count Monday crossings, just distance
-			return (enddate.days - startdate.days) / Interval::DAYS_PER_WEEK;
+			return (enddate.days - startdate.days) / Interval::DUCKDB_DAYS_PER_WEEK;
 		}
 	};
 
@@ -113,8 +113,8 @@ struct DateDiff {
 	struct MillisecondsOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA startdate, TB enddate) {
-			return Date::EpochMicroseconds(enddate) / Interval::MICROS_PER_MSEC -
-			       Date::EpochMicroseconds(startdate) / Interval::MICROS_PER_MSEC;
+			return Date::EpochMicroseconds(enddate) / Interval::DUCKDB_MICROS_PER_MSEC -
+			       Date::EpochMicroseconds(startdate) / Interval::DUCKDB_MICROS_PER_MSEC;
 		}
 	};
 
@@ -128,15 +128,15 @@ struct DateDiff {
 	struct MinutesOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA startdate, TB enddate) {
-			return Date::Epoch(enddate) / Interval::SECS_PER_MINUTE -
-			       Date::Epoch(startdate) / Interval::SECS_PER_MINUTE;
+			return Date::Epoch(enddate) / Interval::DUCKDB_SECS_PER_MINUTE -
+			       Date::Epoch(startdate) / Interval::DUCKDB_SECS_PER_MINUTE;
 		}
 	};
 
 	struct HoursOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA startdate, TB enddate) {
-			return Date::Epoch(enddate) / Interval::SECS_PER_HOUR - Date::Epoch(startdate) / Interval::SECS_PER_HOUR;
+			return Date::Epoch(enddate) / Interval::DUCKDB_SECS_PER_HOUR - Date::Epoch(startdate) / Interval::DUCKDB_SECS_PER_HOUR;
 		}
 	};
 };
@@ -218,16 +218,16 @@ template <>
 int64_t DateDiff::MinutesOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
 	D_ASSERT(Timestamp::IsFinite(startdate));
 	D_ASSERT(Timestamp::IsFinite(enddate));
-	return Timestamp::GetEpochSeconds(enddate) / Interval::SECS_PER_MINUTE -
-	       Timestamp::GetEpochSeconds(startdate) / Interval::SECS_PER_MINUTE;
+	return Timestamp::GetEpochSeconds(enddate) / Interval::DUCKDB_SECS_PER_MINUTE -
+	       Timestamp::GetEpochSeconds(startdate) / Interval::DUCKDB_SECS_PER_MINUTE;
 }
 
 template <>
 int64_t DateDiff::HoursOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
 	D_ASSERT(Timestamp::IsFinite(startdate));
 	D_ASSERT(Timestamp::IsFinite(enddate));
-	return Timestamp::GetEpochSeconds(enddate) / Interval::SECS_PER_HOUR -
-	       Timestamp::GetEpochSeconds(startdate) / Interval::SECS_PER_HOUR;
+	return Timestamp::GetEpochSeconds(enddate) / Interval::DUCKDB_SECS_PER_HOUR -
+	       Timestamp::GetEpochSeconds(startdate) / Interval::DUCKDB_SECS_PER_HOUR;
 }
 
 // TIME specialisations
@@ -283,22 +283,22 @@ int64_t DateDiff::MicrosecondsOperator::Operation(dtime_t startdate, dtime_t end
 
 template <>
 int64_t DateDiff::MillisecondsOperator::Operation(dtime_t startdate, dtime_t enddate) {
-	return enddate.micros / Interval::MICROS_PER_MSEC - startdate.micros / Interval::MICROS_PER_MSEC;
+	return enddate.micros / Interval::DUCKDB_MICROS_PER_MSEC - startdate.micros / Interval::DUCKDB_MICROS_PER_MSEC;
 }
 
 template <>
 int64_t DateDiff::SecondsOperator::Operation(dtime_t startdate, dtime_t enddate) {
-	return enddate.micros / Interval::MICROS_PER_SEC - startdate.micros / Interval::MICROS_PER_SEC;
+	return enddate.micros / Interval::DUCKDB_MICROS_PER_SEC - startdate.micros / Interval::DUCKDB_MICROS_PER_SEC;
 }
 
 template <>
 int64_t DateDiff::MinutesOperator::Operation(dtime_t startdate, dtime_t enddate) {
-	return enddate.micros / Interval::MICROS_PER_MINUTE - startdate.micros / Interval::MICROS_PER_MINUTE;
+	return enddate.micros / Interval::DUCKDB_MICROS_PER_MINUTE - startdate.micros / Interval::DUCKDB_MICROS_PER_MINUTE;
 }
 
 template <>
 int64_t DateDiff::HoursOperator::Operation(dtime_t startdate, dtime_t enddate) {
-	return enddate.micros / Interval::MICROS_PER_HOUR - startdate.micros / Interval::MICROS_PER_HOUR;
+	return enddate.micros / Interval::DUCKDB_MICROS_PER_HOUR - startdate.micros / Interval::DUCKDB_MICROS_PER_HOUR;
 }
 
 template <typename TA, typename TB, typename TR>

--- a/src/core_functions/scalar/date/date_part.cpp
+++ b/src/core_functions/scalar/date/date_part.cpp
@@ -271,7 +271,7 @@ struct DatePart {
 	struct QuarterOperator {
 		template <class TR>
 		static inline TR QuarterFromMonth(TR mm) {
-			return (mm - 1) / Interval::MONTHS_PER_QUARTER + 1;
+			return (mm - 1) / Interval::DUCKDB_MONTHS_PER_QUARTER + 1;
 		}
 
 		template <class TA, class TR>
@@ -422,7 +422,7 @@ struct DatePart {
 	struct NanosecondsOperator {
 		template <class TA, class TR>
 		static inline TR Operation(TA input) {
-			return MicrosecondsOperator::Operation<TA, TR>(input) * Interval::NANOS_PER_MICRO;
+			return MicrosecondsOperator::Operation<TA, TR>(input) * Interval::DUCKDB_NANOS_PER_MICRO;
 		}
 
 		template <class T>
@@ -532,7 +532,7 @@ struct DatePart {
 			auto time = Time::NormalizeTimeTZ(timetz);
 			date_t date(0);
 			time = Interval::Add(time, interval, date);
-			auto offset = UnsafeNumericCast<int32_t>(interval.micros / Interval::MICROS_PER_SEC);
+			auto offset = UnsafeNumericCast<int32_t>(interval.micros / Interval::DUCKDB_MICROS_PER_SEC);
 			return TR(time, offset);
 		}
 
@@ -782,7 +782,7 @@ int64_t DatePart::YearOperator::Operation(timestamp_t input) {
 
 template <>
 int64_t DatePart::YearOperator::Operation(interval_t input) {
-	return input.months / Interval::MONTHS_PER_YEAR;
+	return input.months / Interval::DUCKDB_MONTHS_PER_YEAR;
 }
 
 template <>
@@ -802,7 +802,7 @@ int64_t DatePart::MonthOperator::Operation(timestamp_t input) {
 
 template <>
 int64_t DatePart::MonthOperator::Operation(interval_t input) {
-	return input.months % Interval::MONTHS_PER_YEAR;
+	return input.months % Interval::DUCKDB_MONTHS_PER_YEAR;
 }
 
 template <>
@@ -837,7 +837,7 @@ int64_t DatePart::DayOperator::Operation(dtime_tz_t input) {
 
 template <>
 int64_t DatePart::DecadeOperator::Operation(interval_t input) {
-	return input.months / Interval::MONTHS_PER_DECADE;
+	return input.months / Interval::DUCKDB_MONTHS_PER_DECADE;
 }
 
 template <>
@@ -852,7 +852,7 @@ int64_t DatePart::DecadeOperator::Operation(dtime_tz_t input) {
 
 template <>
 int64_t DatePart::CenturyOperator::Operation(interval_t input) {
-	return input.months / Interval::MONTHS_PER_CENTURY;
+	return input.months / Interval::DUCKDB_MONTHS_PER_CENTURY;
 }
 
 template <>
@@ -867,7 +867,7 @@ int64_t DatePart::CenturyOperator::Operation(dtime_tz_t input) {
 
 template <>
 int64_t DatePart::MillenniumOperator::Operation(interval_t input) {
-	return input.months / Interval::MONTHS_PER_MILLENIUM;
+	return input.months / Interval::DUCKDB_MONTHS_PER_MILLENIUM;
 }
 
 template <>
@@ -887,7 +887,7 @@ int64_t DatePart::QuarterOperator::Operation(timestamp_t input) {
 
 template <>
 int64_t DatePart::QuarterOperator::Operation(interval_t input) {
-	return MonthOperator::Operation<interval_t, int64_t>(input) / Interval::MONTHS_PER_QUARTER + 1;
+	return MonthOperator::Operation<interval_t, int64_t>(input) / Interval::DUCKDB_MONTHS_PER_QUARTER + 1;
 }
 
 template <>
@@ -1041,7 +1041,7 @@ int64_t DatePart::EpochNanosecondsOperator::Operation(interval_t input) {
 
 template <>
 int64_t DatePart::EpochNanosecondsOperator::Operation(dtime_t input) {
-	return input.micros * Interval::NANOS_PER_MICRO;
+	return input.micros * Interval::DUCKDB_NANOS_PER_MICRO;
 }
 
 template <>
@@ -1087,7 +1087,7 @@ int64_t DatePart::EpochMillisOperator::Operation(interval_t input) {
 
 template <>
 int64_t DatePart::EpochMillisOperator::Operation(dtime_t input) {
-	return input.micros / Interval::MICROS_PER_MSEC;
+	return input.micros / Interval::DUCKDB_MICROS_PER_MSEC;
 }
 
 template <>
@@ -1105,7 +1105,7 @@ int64_t DatePart::NanosecondsOperator::Operation(timestamp_ns_t input) {
 	int32_t nanos;
 	Timestamp::Convert(input, date, time, nanos);
 	// remove everything but the second & nanosecond part
-	return (time.micros % Interval::MICROS_PER_MINUTE) * Interval::NANOS_PER_MICRO + nanos;
+	return (time.micros % Interval::DUCKDB_MICROS_PER_MINUTE) * Interval::DUCKDB_NANOS_PER_MICRO + nanos;
 }
 
 template <>
@@ -1113,19 +1113,19 @@ int64_t DatePart::MicrosecondsOperator::Operation(timestamp_t input) {
 	D_ASSERT(Timestamp::IsFinite(input));
 	auto time = Timestamp::GetTime(input);
 	// remove everything but the second & microsecond part
-	return time.micros % Interval::MICROS_PER_MINUTE;
+	return time.micros % Interval::DUCKDB_MICROS_PER_MINUTE;
 }
 
 template <>
 int64_t DatePart::MicrosecondsOperator::Operation(interval_t input) {
 	// remove everything but the second & microsecond part
-	return input.micros % Interval::MICROS_PER_MINUTE;
+	return input.micros % Interval::DUCKDB_MICROS_PER_MINUTE;
 }
 
 template <>
 int64_t DatePart::MicrosecondsOperator::Operation(dtime_t input) {
 	// remove everything but the second & microsecond part
-	return input.micros % Interval::MICROS_PER_MINUTE;
+	return input.micros % Interval::DUCKDB_MICROS_PER_MINUTE;
 }
 
 template <>
@@ -1136,17 +1136,17 @@ int64_t DatePart::MicrosecondsOperator::Operation(dtime_tz_t input) {
 template <>
 int64_t DatePart::MillisecondsOperator::Operation(timestamp_t input) {
 	D_ASSERT(Timestamp::IsFinite(input));
-	return MicrosecondsOperator::Operation<timestamp_t, int64_t>(input) / Interval::MICROS_PER_MSEC;
+	return MicrosecondsOperator::Operation<timestamp_t, int64_t>(input) / Interval::DUCKDB_MICROS_PER_MSEC;
 }
 
 template <>
 int64_t DatePart::MillisecondsOperator::Operation(interval_t input) {
-	return MicrosecondsOperator::Operation<interval_t, int64_t>(input) / Interval::MICROS_PER_MSEC;
+	return MicrosecondsOperator::Operation<interval_t, int64_t>(input) / Interval::DUCKDB_MICROS_PER_MSEC;
 }
 
 template <>
 int64_t DatePart::MillisecondsOperator::Operation(dtime_t input) {
-	return MicrosecondsOperator::Operation<dtime_t, int64_t>(input) / Interval::MICROS_PER_MSEC;
+	return MicrosecondsOperator::Operation<dtime_t, int64_t>(input) / Interval::DUCKDB_MICROS_PER_MSEC;
 }
 
 template <>
@@ -1157,17 +1157,17 @@ int64_t DatePart::MillisecondsOperator::Operation(dtime_tz_t input) {
 template <>
 int64_t DatePart::SecondsOperator::Operation(timestamp_t input) {
 	D_ASSERT(Timestamp::IsFinite(input));
-	return MicrosecondsOperator::Operation<timestamp_t, int64_t>(input) / Interval::MICROS_PER_SEC;
+	return MicrosecondsOperator::Operation<timestamp_t, int64_t>(input) / Interval::DUCKDB_MICROS_PER_SEC;
 }
 
 template <>
 int64_t DatePart::SecondsOperator::Operation(interval_t input) {
-	return MicrosecondsOperator::Operation<interval_t, int64_t>(input) / Interval::MICROS_PER_SEC;
+	return MicrosecondsOperator::Operation<interval_t, int64_t>(input) / Interval::DUCKDB_MICROS_PER_SEC;
 }
 
 template <>
 int64_t DatePart::SecondsOperator::Operation(dtime_t input) {
-	return MicrosecondsOperator::Operation<dtime_t, int64_t>(input) / Interval::MICROS_PER_SEC;
+	return MicrosecondsOperator::Operation<dtime_t, int64_t>(input) / Interval::DUCKDB_MICROS_PER_SEC;
 }
 
 template <>
@@ -1180,19 +1180,19 @@ int64_t DatePart::MinutesOperator::Operation(timestamp_t input) {
 	D_ASSERT(Timestamp::IsFinite(input));
 	auto time = Timestamp::GetTime(input);
 	// remove the hour part, and truncate to minutes
-	return (time.micros % Interval::MICROS_PER_HOUR) / Interval::MICROS_PER_MINUTE;
+	return (time.micros % Interval::DUCKDB_MICROS_PER_HOUR) / Interval::DUCKDB_MICROS_PER_MINUTE;
 }
 
 template <>
 int64_t DatePart::MinutesOperator::Operation(interval_t input) {
 	// remove the hour part, and truncate to minutes
-	return (input.micros % Interval::MICROS_PER_HOUR) / Interval::MICROS_PER_MINUTE;
+	return (input.micros % Interval::DUCKDB_MICROS_PER_HOUR) / Interval::DUCKDB_MICROS_PER_MINUTE;
 }
 
 template <>
 int64_t DatePart::MinutesOperator::Operation(dtime_t input) {
 	// remove the hour part, and truncate to minutes
-	return (input.micros % Interval::MICROS_PER_HOUR) / Interval::MICROS_PER_MINUTE;
+	return (input.micros % Interval::DUCKDB_MICROS_PER_HOUR) / Interval::DUCKDB_MICROS_PER_MINUTE;
 }
 
 template <>
@@ -1203,17 +1203,17 @@ int64_t DatePart::MinutesOperator::Operation(dtime_tz_t input) {
 template <>
 int64_t DatePart::HoursOperator::Operation(timestamp_t input) {
 	D_ASSERT(Timestamp::IsFinite(input));
-	return Timestamp::GetTime(input).micros / Interval::MICROS_PER_HOUR;
+	return Timestamp::GetTime(input).micros / Interval::DUCKDB_MICROS_PER_HOUR;
 }
 
 template <>
 int64_t DatePart::HoursOperator::Operation(interval_t input) {
-	return input.micros / Interval::MICROS_PER_HOUR;
+	return input.micros / Interval::DUCKDB_MICROS_PER_HOUR;
 }
 
 template <>
 int64_t DatePart::HoursOperator::Operation(dtime_t input) {
-	return input.micros / Interval::MICROS_PER_HOUR;
+	return input.micros / Interval::DUCKDB_MICROS_PER_HOUR;
 }
 
 template <>
@@ -1224,21 +1224,21 @@ int64_t DatePart::HoursOperator::Operation(dtime_tz_t input) {
 template <>
 double DatePart::EpochOperator::Operation(timestamp_t input) {
 	D_ASSERT(Timestamp::IsFinite(input));
-	return double(Timestamp::GetEpochMicroSeconds(input)) / double(Interval::MICROS_PER_SEC);
+	return double(Timestamp::GetEpochMicroSeconds(input)) / double(Interval::DUCKDB_MICROS_PER_SEC);
 }
 
 template <>
 double DatePart::EpochOperator::Operation(interval_t input) {
-	int64_t interval_years = input.months / Interval::MONTHS_PER_YEAR;
+	int64_t interval_years = input.months / Interval::DUCKDB_MONTHS_PER_YEAR;
 	int64_t interval_days;
-	interval_days = Interval::DAYS_PER_YEAR * interval_years;
-	interval_days += Interval::DAYS_PER_MONTH * (input.months % Interval::MONTHS_PER_YEAR);
+	interval_days = Interval::DUCKDB_DAYS_PER_YEAR * interval_years;
+	interval_days += Interval::DUCKDB_DAYS_PER_MONTH * (input.months % Interval::DUCKDB_MONTHS_PER_YEAR);
 	interval_days += input.days;
 	int64_t interval_epoch;
-	interval_epoch = interval_days * Interval::SECS_PER_DAY;
+	interval_epoch = interval_days * Interval::DUCKDB_SECS_PER_DAY;
 	// we add 0.25 days per year to sort of account for leap days
-	interval_epoch += interval_years * (Interval::SECS_PER_DAY / 4);
-	return double(interval_epoch) + double(input.micros) / double(Interval::MICROS_PER_SEC);
+	interval_epoch += interval_years * (Interval::DUCKDB_SECS_PER_DAY / 4);
+	return double(interval_epoch) + double(input.micros) / double(Interval::DUCKDB_MICROS_PER_SEC);
 }
 
 //	TODO: We can't propagate interval statistics because we can't easily compare interval_t for order.
@@ -1250,7 +1250,7 @@ unique_ptr<BaseStatistics> DatePart::EpochOperator::PropagateStatistics<interval
 
 template <>
 double DatePart::EpochOperator::Operation(dtime_t input) {
-	return double(input.micros) / double(Interval::MICROS_PER_SEC);
+	return double(input.micros) / double(Interval::DUCKDB_MICROS_PER_SEC);
 }
 
 template <>
@@ -1264,7 +1264,7 @@ unique_ptr<BaseStatistics> DatePart::EpochOperator::PropagateStatistics<dtime_t>
 	auto result = NumericStats::CreateEmpty(LogicalType::DOUBLE);
 	result.CopyValidity(input.child_stats[0]);
 	NumericStats::SetMin(result, Value::DOUBLE(0));
-	NumericStats::SetMax(result, Value::DOUBLE(Interval::SECS_PER_DAY));
+	NumericStats::SetMax(result, Value::DOUBLE(Interval::DUCKDB_SECS_PER_DAY));
 	return result.ToUnique();
 }
 
@@ -1316,7 +1316,7 @@ int64_t DatePart::TimezoneHourOperator::Operation(interval_t input) {
 
 template <>
 int64_t DatePart::TimezoneHourOperator::Operation(dtime_tz_t input) {
-	return input.offset() / Interval::SECS_PER_HOUR;
+	return input.offset() / Interval::DUCKDB_SECS_PER_HOUR;
 }
 
 template <>
@@ -1331,7 +1331,7 @@ int64_t DatePart::TimezoneMinuteOperator::Operation(interval_t input) {
 
 template <>
 int64_t DatePart::TimezoneMinuteOperator::Operation(dtime_tz_t input) {
-	return (input.offset() / Interval::SECS_PER_MINUTE) % Interval::MINS_PER_HOUR;
+	return (input.offset() / Interval::DUCKDB_SECS_PER_MINUTE) % Interval::DUCKDB_MINS_PER_HOUR;
 }
 
 template <>
@@ -1366,11 +1366,11 @@ void DatePart::StructOperator::Operation(bigint_vec &bigint_values, double_vec &
 		}
 		part_data = HasPartValue(bigint_values, DatePartSpecifier::MILLISECONDS);
 		if (part_data) {
-			part_data[idx] = micros / Interval::MICROS_PER_MSEC;
+			part_data[idx] = micros / Interval::DUCKDB_MICROS_PER_MSEC;
 		}
 		part_data = HasPartValue(bigint_values, DatePartSpecifier::SECOND);
 		if (part_data) {
-			part_data[idx] = micros / Interval::MICROS_PER_SEC;
+			part_data[idx] = micros / Interval::DUCKDB_MICROS_PER_SEC;
 		}
 		part_data = HasPartValue(bigint_values, DatePartSpecifier::MINUTE);
 		if (part_data) {
@@ -1417,11 +1417,11 @@ void DatePart::StructOperator::Operation(bigint_vec &bigint_values, double_vec &
 		}
 		part_data = HasPartValue(bigint_values, DatePartSpecifier::MILLISECONDS);
 		if (part_data) {
-			part_data[idx] = micros / Interval::MICROS_PER_MSEC;
+			part_data[idx] = micros / Interval::DUCKDB_MICROS_PER_MSEC;
 		}
 		part_data = HasPartValue(bigint_values, DatePartSpecifier::SECOND);
 		if (part_data) {
-			part_data[idx] = micros / Interval::MICROS_PER_SEC;
+			part_data[idx] = micros / Interval::DUCKDB_MICROS_PER_SEC;
 		}
 		part_data = HasPartValue(bigint_values, DatePartSpecifier::MINUTE);
 		if (part_data) {
@@ -1490,10 +1490,10 @@ void DatePart::StructOperator::Operation(bigint_vec &bigint_values, double_vec &
                                          const idx_t idx, const part_mask_t mask) {
 	int64_t *part_data;
 	if (mask & YMD) {
-		const auto mm = input.months % Interval::MONTHS_PER_YEAR;
+		const auto mm = input.months % Interval::DUCKDB_MONTHS_PER_YEAR;
 		part_data = HasPartValue(bigint_values, DatePartSpecifier::YEAR);
 		if (part_data) {
-			part_data[idx] = input.months / Interval::MONTHS_PER_YEAR;
+			part_data[idx] = input.months / Interval::DUCKDB_MONTHS_PER_YEAR;
 		}
 		part_data = HasPartValue(bigint_values, DatePartSpecifier::MONTH);
 		if (part_data) {
@@ -1505,19 +1505,19 @@ void DatePart::StructOperator::Operation(bigint_vec &bigint_values, double_vec &
 		}
 		part_data = HasPartValue(bigint_values, DatePartSpecifier::DECADE);
 		if (part_data) {
-			part_data[idx] = input.months / Interval::MONTHS_PER_DECADE;
+			part_data[idx] = input.months / Interval::DUCKDB_MONTHS_PER_DECADE;
 		}
 		part_data = HasPartValue(bigint_values, DatePartSpecifier::CENTURY);
 		if (part_data) {
-			part_data[idx] = input.months / Interval::MONTHS_PER_CENTURY;
+			part_data[idx] = input.months / Interval::DUCKDB_MONTHS_PER_CENTURY;
 		}
 		part_data = HasPartValue(bigint_values, DatePartSpecifier::MILLENNIUM);
 		if (part_data) {
-			part_data[idx] = input.months / Interval::MONTHS_PER_MILLENIUM;
+			part_data[idx] = input.months / Interval::DUCKDB_MONTHS_PER_MILLENIUM;
 		}
 		part_data = HasPartValue(bigint_values, DatePartSpecifier::QUARTER);
 		if (part_data) {
-			part_data[idx] = mm / Interval::MONTHS_PER_QUARTER + 1;
+			part_data[idx] = mm / Interval::DUCKDB_MONTHS_PER_QUARTER + 1;
 		}
 	}
 
@@ -1529,11 +1529,11 @@ void DatePart::StructOperator::Operation(bigint_vec &bigint_values, double_vec &
 		}
 		part_data = HasPartValue(bigint_values, DatePartSpecifier::MILLISECONDS);
 		if (part_data) {
-			part_data[idx] = micros / Interval::MICROS_PER_MSEC;
+			part_data[idx] = micros / Interval::DUCKDB_MICROS_PER_MSEC;
 		}
 		part_data = HasPartValue(bigint_values, DatePartSpecifier::SECOND);
 		if (part_data) {
-			part_data[idx] = micros / Interval::MICROS_PER_SEC;
+			part_data[idx] = micros / Interval::DUCKDB_MICROS_PER_SEC;
 		}
 		part_data = HasPartValue(bigint_values, DatePartSpecifier::MINUTE);
 		if (part_data) {

--- a/src/core_functions/scalar/date/date_sub.cpp
+++ b/src/core_functions/scalar/date/date_sub.cpp
@@ -70,49 +70,49 @@ struct DateSub {
 	struct QuarterOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA start_ts, TB end_ts) {
-			return MonthOperator::Operation<TA, TB, TR>(start_ts, end_ts) / Interval::MONTHS_PER_QUARTER;
+			return MonthOperator::Operation<TA, TB, TR>(start_ts, end_ts) / Interval::DUCKDB_MONTHS_PER_QUARTER;
 		}
 	};
 
 	struct YearOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA start_ts, TB end_ts) {
-			return MonthOperator::Operation<TA, TB, TR>(start_ts, end_ts) / Interval::MONTHS_PER_YEAR;
+			return MonthOperator::Operation<TA, TB, TR>(start_ts, end_ts) / Interval::DUCKDB_MONTHS_PER_YEAR;
 		}
 	};
 
 	struct DecadeOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA start_ts, TB end_ts) {
-			return MonthOperator::Operation<TA, TB, TR>(start_ts, end_ts) / Interval::MONTHS_PER_DECADE;
+			return MonthOperator::Operation<TA, TB, TR>(start_ts, end_ts) / Interval::DUCKDB_MONTHS_PER_DECADE;
 		}
 	};
 
 	struct CenturyOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA start_ts, TB end_ts) {
-			return MonthOperator::Operation<TA, TB, TR>(start_ts, end_ts) / Interval::MONTHS_PER_CENTURY;
+			return MonthOperator::Operation<TA, TB, TR>(start_ts, end_ts) / Interval::DUCKDB_MONTHS_PER_CENTURY;
 		}
 	};
 
 	struct MilleniumOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA start_ts, TB end_ts) {
-			return MonthOperator::Operation<TA, TB, TR>(start_ts, end_ts) / Interval::MONTHS_PER_MILLENIUM;
+			return MonthOperator::Operation<TA, TB, TR>(start_ts, end_ts) / Interval::DUCKDB_MONTHS_PER_MILLENIUM;
 		}
 	};
 
 	struct DayOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA startdate, TB enddate) {
-			return SubtractMicros(startdate, enddate) / Interval::MICROS_PER_DAY;
+			return SubtractMicros(startdate, enddate) / Interval::DUCKDB_MICROS_PER_DAY;
 		}
 	};
 
 	struct WeekOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA startdate, TB enddate) {
-			return SubtractMicros(startdate, enddate) / Interval::MICROS_PER_WEEK;
+			return SubtractMicros(startdate, enddate) / Interval::DUCKDB_MICROS_PER_WEEK;
 		}
 	};
 
@@ -126,28 +126,28 @@ struct DateSub {
 	struct MillisecondsOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA startdate, TB enddate) {
-			return SubtractMicros(startdate, enddate) / Interval::MICROS_PER_MSEC;
+			return SubtractMicros(startdate, enddate) / Interval::DUCKDB_MICROS_PER_MSEC;
 		}
 	};
 
 	struct SecondsOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA startdate, TB enddate) {
-			return SubtractMicros(startdate, enddate) / Interval::MICROS_PER_SEC;
+			return SubtractMicros(startdate, enddate) / Interval::DUCKDB_MICROS_PER_SEC;
 		}
 	};
 
 	struct MinutesOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA startdate, TB enddate) {
-			return SubtractMicros(startdate, enddate) / Interval::MICROS_PER_MINUTE;
+			return SubtractMicros(startdate, enddate) / Interval::DUCKDB_MICROS_PER_MINUTE;
 		}
 	};
 
 	struct HoursOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA startdate, TB enddate) {
-			return SubtractMicros(startdate, enddate) / Interval::MICROS_PER_HOUR;
+			return SubtractMicros(startdate, enddate) / Interval::DUCKDB_MICROS_PER_HOUR;
 		}
 	};
 };
@@ -292,22 +292,22 @@ int64_t DateSub::MicrosecondsOperator::Operation(dtime_t startdate, dtime_t endd
 
 template <>
 int64_t DateSub::MillisecondsOperator::Operation(dtime_t startdate, dtime_t enddate) {
-	return (enddate.micros - startdate.micros) / Interval::MICROS_PER_MSEC;
+	return (enddate.micros - startdate.micros) / Interval::DUCKDB_MICROS_PER_MSEC;
 }
 
 template <>
 int64_t DateSub::SecondsOperator::Operation(dtime_t startdate, dtime_t enddate) {
-	return (enddate.micros - startdate.micros) / Interval::MICROS_PER_SEC;
+	return (enddate.micros - startdate.micros) / Interval::DUCKDB_MICROS_PER_SEC;
 }
 
 template <>
 int64_t DateSub::MinutesOperator::Operation(dtime_t startdate, dtime_t enddate) {
-	return (enddate.micros - startdate.micros) / Interval::MICROS_PER_MINUTE;
+	return (enddate.micros - startdate.micros) / Interval::DUCKDB_MICROS_PER_MINUTE;
 }
 
 template <>
 int64_t DateSub::HoursOperator::Operation(dtime_t startdate, dtime_t enddate) {
-	return (enddate.micros - startdate.micros) / Interval::MICROS_PER_HOUR;
+	return (enddate.micros - startdate.micros) / Interval::DUCKDB_MICROS_PER_HOUR;
 }
 
 template <typename TA, typename TB, typename TR>

--- a/src/core_functions/scalar/date/date_trunc.cpp
+++ b/src/core_functions/scalar/date/date_trunc.cpp
@@ -81,7 +81,7 @@ struct DateTrunc {
 		template <class TA, class TR>
 		static inline TR Operation(TA input) {
 			date_t date = Date::GetMondayOfCurrentWeek(input);
-			date.days -= (Date::ExtractISOWeekNumber(date) - 1) * Interval::DAYS_PER_WEEK;
+			date.days -= (Date::ExtractISOWeekNumber(date) - 1) * Interval::DUCKDB_DAYS_PER_WEEK;
 
 			return date;
 		}
@@ -138,7 +138,7 @@ struct DateTrunc {
 			dtime_t time;
 			Timestamp::Convert(input, date, time);
 			Time::Convert(time, hour, min, sec, micros);
-			micros -= UnsafeNumericCast<int32_t>(micros % Interval::MICROS_PER_MSEC);
+			micros -= UnsafeNumericCast<int32_t>(micros % Interval::DUCKDB_MICROS_PER_MSEC);
 			return Timestamp::FromDatetime(date, Time::FromTime(hour, min, sec, micros));
 		}
 	};
@@ -367,7 +367,7 @@ template <>
 interval_t DateTrunc::MillenniumOperator::Operation(interval_t input) {
 	input.days = 0;
 	input.micros = 0;
-	input.months = (input.months / Interval::MONTHS_PER_MILLENIUM) * Interval::MONTHS_PER_MILLENIUM;
+	input.months = (input.months / Interval::DUCKDB_MONTHS_PER_MILLENIUM) * Interval::DUCKDB_MONTHS_PER_MILLENIUM;
 	return input;
 }
 
@@ -375,7 +375,7 @@ template <>
 interval_t DateTrunc::CenturyOperator::Operation(interval_t input) {
 	input.days = 0;
 	input.micros = 0;
-	input.months = (input.months / Interval::MONTHS_PER_CENTURY) * Interval::MONTHS_PER_CENTURY;
+	input.months = (input.months / Interval::DUCKDB_MONTHS_PER_CENTURY) * Interval::DUCKDB_MONTHS_PER_CENTURY;
 	return input;
 }
 
@@ -383,7 +383,7 @@ template <>
 interval_t DateTrunc::DecadeOperator::Operation(interval_t input) {
 	input.days = 0;
 	input.micros = 0;
-	input.months = (input.months / Interval::MONTHS_PER_DECADE) * Interval::MONTHS_PER_DECADE;
+	input.months = (input.months / Interval::DUCKDB_MONTHS_PER_DECADE) * Interval::DUCKDB_MONTHS_PER_DECADE;
 	return input;
 }
 
@@ -391,7 +391,7 @@ template <>
 interval_t DateTrunc::YearOperator::Operation(interval_t input) {
 	input.days = 0;
 	input.micros = 0;
-	input.months = (input.months / Interval::MONTHS_PER_YEAR) * Interval::MONTHS_PER_YEAR;
+	input.months = (input.months / Interval::DUCKDB_MONTHS_PER_YEAR) * Interval::DUCKDB_MONTHS_PER_YEAR;
 	return input;
 }
 
@@ -399,7 +399,7 @@ template <>
 interval_t DateTrunc::QuarterOperator::Operation(interval_t input) {
 	input.days = 0;
 	input.micros = 0;
-	input.months = (input.months / Interval::MONTHS_PER_QUARTER) * Interval::MONTHS_PER_QUARTER;
+	input.months = (input.months / Interval::DUCKDB_MONTHS_PER_QUARTER) * Interval::DUCKDB_MONTHS_PER_QUARTER;
 	return input;
 }
 
@@ -413,7 +413,7 @@ interval_t DateTrunc::MonthOperator::Operation(interval_t input) {
 template <>
 interval_t DateTrunc::WeekOperator::Operation(interval_t input) {
 	input.micros = 0;
-	input.days = (input.days / Interval::DAYS_PER_WEEK) * Interval::DAYS_PER_WEEK;
+	input.days = (input.days / Interval::DUCKDB_DAYS_PER_WEEK) * Interval::DUCKDB_DAYS_PER_WEEK;
 	return input;
 }
 
@@ -430,25 +430,25 @@ interval_t DateTrunc::DayOperator::Operation(interval_t input) {
 
 template <>
 interval_t DateTrunc::HourOperator::Operation(interval_t input) {
-	input.micros = (input.micros / Interval::MICROS_PER_HOUR) * Interval::MICROS_PER_HOUR;
+	input.micros = (input.micros / Interval::DUCKDB_MICROS_PER_HOUR) * Interval::DUCKDB_MICROS_PER_HOUR;
 	return input;
 }
 
 template <>
 interval_t DateTrunc::MinuteOperator::Operation(interval_t input) {
-	input.micros = (input.micros / Interval::MICROS_PER_MINUTE) * Interval::MICROS_PER_MINUTE;
+	input.micros = (input.micros / Interval::DUCKDB_MICROS_PER_MINUTE) * Interval::DUCKDB_MICROS_PER_MINUTE;
 	return input;
 }
 
 template <>
 interval_t DateTrunc::SecondOperator::Operation(interval_t input) {
-	input.micros = (input.micros / Interval::MICROS_PER_SEC) * Interval::MICROS_PER_SEC;
+	input.micros = (input.micros / Interval::DUCKDB_MICROS_PER_SEC) * Interval::DUCKDB_MICROS_PER_SEC;
 	return input;
 }
 
 template <>
 interval_t DateTrunc::MillisecondOperator::Operation(interval_t input) {
-	input.micros = (input.micros / Interval::MICROS_PER_MSEC) * Interval::MICROS_PER_MSEC;
+	input.micros = (input.micros / Interval::DUCKDB_MICROS_PER_MSEC) * Interval::DUCKDB_MICROS_PER_MSEC;
 	return input;
 }
 

--- a/src/core_functions/scalar/date/epoch.cpp
+++ b/src/core_functions/scalar/date/epoch.cpp
@@ -10,7 +10,7 @@ struct EpochSecOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE sec) {
 		int64_t result;
-		if (!TryCast::Operation(sec * Interval::MICROS_PER_SEC, result)) {
+		if (!TryCast::Operation(sec * Interval::DUCKDB_MICROS_PER_SEC, result)) {
 			throw ConversionException("Could not convert epoch seconds to TIMESTAMP WITH TIME ZONE");
 		}
 		return timestamp_t(result);

--- a/src/core_functions/scalar/date/make_date.cpp
+++ b/src/core_functions/scalar/date/make_date.cpp
@@ -63,12 +63,12 @@ struct MakeTimeOperator {
 		auto mm_32 = Cast::Operation<MM, int32_t>(mm);
 		// Have to check this separately because safe casting of DOUBLE => INT32 can round.
 		int32_t ss_32 = 0;
-		if (ss < 0 || ss > Interval::SECS_PER_MINUTE) {
+		if (ss < 0 || ss > Interval::DUCKDB_SECS_PER_MINUTE) {
 			ss_32 = Cast::Operation<SS, int32_t>(ss);
 		} else {
 			ss_32 = LossyNumericCast<int32_t>(ss);
 		}
-		auto micros = LossyNumericCast<int32_t>(std::round((ss - ss_32) * Interval::MICROS_PER_SEC));
+		auto micros = LossyNumericCast<int32_t>(std::round((ss - ss_32) * Interval::DUCKDB_MICROS_PER_SEC));
 
 		if (!Time::IsValidTime(hh_32, mm_32, ss_32, micros)) {
 			throw ConversionException("Time out of range: %d:%d:%d.%d", hh_32, mm_32, ss_32, micros);

--- a/src/core_functions/scalar/date/time_bucket.cpp
+++ b/src/core_functions/scalar/date/time_bucket.cpp
@@ -17,7 +17,7 @@ struct TimeBucket {
 
 	// Use 2000-01-03 00:00:00 (Monday) as origin when bucket_width is days, hours, ... for TimescaleDB compatibility
 	// There are 10959 days between 1970-01-01 and 2000-01-03
-	constexpr static const int64_t DEFAULT_ORIGIN_MICROS = 10959 * Interval::MICROS_PER_DAY;
+	constexpr static const int64_t DEFAULT_ORIGIN_MICROS = 10959 * Interval::DUCKDB_MICROS_PER_DAY;
 	// Use 2000-01-01 as origin when bucket_width is months, years, ... for TimescaleDB compatibility
 	// There are 360 months between 1970-01-01 and 2000-01-01
 	constexpr static const int32_t DEFAULT_ORIGIN_MONTHS = 360;

--- a/src/core_functions/scalar/date/to_interval.cpp
+++ b/src/core_functions/scalar/date/to_interval.cpp
@@ -17,7 +17,7 @@ struct ToMillenniaOperator {
 		interval_t result;
 		result.days = 0;
 		result.micros = 0;
-		if (!TryMultiplyOperator::Operation<TA, int32_t, int32_t>(input, Interval::MONTHS_PER_MILLENIUM,
+		if (!TryMultiplyOperator::Operation<TA, int32_t, int32_t>(input, Interval::DUCKDB_MONTHS_PER_MILLENIUM,
 		                                                          result.months)) {
 			throw OutOfRangeException("Interval value %s millennia out of range", NumericHelper::ToString(input));
 		}
@@ -31,7 +31,7 @@ struct ToCenturiesOperator {
 		interval_t result;
 		result.days = 0;
 		result.micros = 0;
-		if (!TryMultiplyOperator::Operation<TA, int32_t, int32_t>(input, Interval::MONTHS_PER_CENTURY, result.months)) {
+		if (!TryMultiplyOperator::Operation<TA, int32_t, int32_t>(input, Interval::DUCKDB_MONTHS_PER_CENTURY, result.months)) {
 			throw OutOfRangeException("Interval value %s centuries out of range", NumericHelper::ToString(input));
 		}
 		return result;
@@ -44,7 +44,7 @@ struct ToDecadesOperator {
 		interval_t result;
 		result.days = 0;
 		result.micros = 0;
-		if (!TryMultiplyOperator::Operation<TA, int32_t, int32_t>(input, Interval::MONTHS_PER_DECADE, result.months)) {
+		if (!TryMultiplyOperator::Operation<TA, int32_t, int32_t>(input, Interval::DUCKDB_MONTHS_PER_DECADE, result.months)) {
 			throw OutOfRangeException("Interval value %s decades out of range", NumericHelper::ToString(input));
 		}
 		return result;
@@ -57,7 +57,7 @@ struct ToYearsOperator {
 		interval_t result;
 		result.days = 0;
 		result.micros = 0;
-		if (!TryMultiplyOperator::Operation<int32_t, int32_t, int32_t>(input, Interval::MONTHS_PER_YEAR,
+		if (!TryMultiplyOperator::Operation<int32_t, int32_t, int32_t>(input, Interval::DUCKDB_MONTHS_PER_YEAR,
 		                                                               result.months)) {
 			throw OutOfRangeException("Interval value %d years out of range", input);
 		}
@@ -69,7 +69,7 @@ struct ToQuartersOperator {
 	template <class TA, class TR>
 	static inline TR Operation(TA input) {
 		interval_t result;
-		if (!TryMultiplyOperator::Operation<int32_t, int32_t, int32_t>(input, Interval::MONTHS_PER_QUARTER,
+		if (!TryMultiplyOperator::Operation<int32_t, int32_t, int32_t>(input, Interval::DUCKDB_MONTHS_PER_QUARTER,
 		                                                               result.months)) {
 			throw OutOfRangeException("Interval value %d quarters out of range", input);
 		}
@@ -95,7 +95,7 @@ struct ToWeeksOperator {
 	static inline TR Operation(TA input) {
 		interval_t result;
 		result.months = 0;
-		if (!TryMultiplyOperator::Operation<int32_t, int32_t, int32_t>(input, Interval::DAYS_PER_WEEK, result.days)) {
+		if (!TryMultiplyOperator::Operation<int32_t, int32_t, int32_t>(input, Interval::DUCKDB_DAYS_PER_WEEK, result.days)) {
 			throw OutOfRangeException("Interval value %d weeks out of range", input);
 		}
 		result.micros = 0;
@@ -120,7 +120,7 @@ struct ToHoursOperator {
 		interval_t result;
 		result.months = 0;
 		result.days = 0;
-		if (!TryMultiplyOperator::Operation<TA, int64_t, int64_t>(input, Interval::MICROS_PER_HOUR, result.micros)) {
+		if (!TryMultiplyOperator::Operation<TA, int64_t, int64_t>(input, Interval::DUCKDB_MICROS_PER_HOUR, result.micros)) {
 			throw OutOfRangeException("Interval value %s hours out of range", NumericHelper::ToString(input));
 		}
 		return result;
@@ -133,7 +133,7 @@ struct ToMinutesOperator {
 		interval_t result;
 		result.months = 0;
 		result.days = 0;
-		if (!TryMultiplyOperator::Operation<TA, int64_t, int64_t>(input, Interval::MICROS_PER_MINUTE, result.micros)) {
+		if (!TryMultiplyOperator::Operation<TA, int64_t, int64_t>(input, Interval::DUCKDB_MICROS_PER_MINUTE, result.micros)) {
 			throw OutOfRangeException("Interval value %s minutes out of range", NumericHelper::ToString(input));
 		}
 		return result;
@@ -146,7 +146,7 @@ struct ToMilliSecondsOperator {
 		interval_t result;
 		result.months = 0;
 		result.days = 0;
-		if (!TryMultiplyOperator::Operation<TA, int64_t, int64_t>(input, Interval::MICROS_PER_MSEC, result.micros)) {
+		if (!TryMultiplyOperator::Operation<TA, int64_t, int64_t>(input, Interval::DUCKDB_MICROS_PER_MSEC, result.micros)) {
 			throw OutOfRangeException("Interval value %s milliseconds out of range", NumericHelper::ToString(input));
 		}
 		return result;

--- a/src/function/scalar/generic/binning.cpp
+++ b/src/function/scalar/generic/binning.cpp
@@ -268,19 +268,19 @@ timestamp_t MakeTimestampNice(int32_t year, int32_t month, int32_t day, int32_t 
 			NextDay(year, month, day);
 			hour = minute = sec = micros = 0;
 		}
-	} else if (step.days > 0 || step.micros >= Interval::MICROS_PER_HOUR) {
+	} else if (step.days > 0 || step.micros >= Interval::DUCKDB_MICROS_PER_HOUR) {
 		// if the step involves more than one hour, ceil to hours
 		if (minute > 0 || sec > 0 || micros > 0) {
 			NextHour(year, month, day, hour);
 			minute = sec = micros = 0;
 		}
-	} else if (step.micros >= Interval::MICROS_PER_MINUTE) {
+	} else if (step.micros >= Interval::DUCKDB_MICROS_PER_MINUTE) {
 		// if the step involves more than one minute, ceil to minutes
 		if (sec > 0 || micros > 0) {
 			NextMinute(year, month, day, hour, minute);
 			sec = micros = 0;
 		}
-	} else if (step.micros >= Interval::MICROS_PER_SEC) {
+	} else if (step.micros >= Interval::DUCKDB_MICROS_PER_SEC) {
 		// if the step involves more than one second, ceil to seconds
 		if (micros > 0) {
 			NextSecond(year, month, day, hour, minute, sec);
@@ -302,21 +302,21 @@ interval_t MakeIntervalNice(interval_t interval) {
 	} else if (interval.months > 0 || interval.days >= 5) {
 		// if we have any months or more than 5 days, we don't care about micros
 		interval.micros = 0;
-	} else if (interval.days > 0 || interval.micros >= 6 * Interval::MICROS_PER_HOUR) {
+	} else if (interval.days > 0 || interval.micros >= 6 * Interval::DUCKDB_MICROS_PER_HOUR) {
 		// if we any days or more than 6 hours, we want micros to be roundable by hours at least
-		interval.micros = RoundNumberToDivisor(interval.micros, Interval::MICROS_PER_HOUR);
-	} else if (interval.micros >= Interval::MICROS_PER_HOUR) {
+		interval.micros = RoundNumberToDivisor(interval.micros, Interval::DUCKDB_MICROS_PER_HOUR);
+	} else if (interval.micros >= Interval::DUCKDB_MICROS_PER_HOUR) {
 		// if we have more than an hour, we want micros to be divisible by quarter hours
-		interval.micros = RoundNumberToDivisor(interval.micros, Interval::MICROS_PER_MINUTE * 15);
-	} else if (interval.micros >= Interval::MICROS_PER_MINUTE * 10) {
+		interval.micros = RoundNumberToDivisor(interval.micros, Interval::DUCKDB_MICROS_PER_MINUTE * 15);
+	} else if (interval.micros >= Interval::DUCKDB_MICROS_PER_MINUTE * 10) {
 		// if we have more than 10 minutes, we want micros to be divisible by minutes
-		interval.micros = RoundNumberToDivisor(interval.micros, Interval::MICROS_PER_MINUTE);
-	} else if (interval.micros >= Interval::MICROS_PER_MINUTE) {
+		interval.micros = RoundNumberToDivisor(interval.micros, Interval::DUCKDB_MICROS_PER_MINUTE);
+	} else if (interval.micros >= Interval::DUCKDB_MICROS_PER_MINUTE) {
 		// if we have more than a minute, we want micros to be divisible by quarter minutes
-		interval.micros = RoundNumberToDivisor(interval.micros, Interval::MICROS_PER_SEC * 15);
-	} else if (interval.micros >= Interval::MICROS_PER_SEC * 10) {
+		interval.micros = RoundNumberToDivisor(interval.micros, Interval::DUCKDB_MICROS_PER_SEC * 15);
+	} else if (interval.micros >= Interval::DUCKDB_MICROS_PER_SEC * 10) {
 		// if we have more than 10 seconds, we want micros to be divisible by seconds
-		interval.micros = RoundNumberToDivisor(interval.micros, Interval::MICROS_PER_SEC);
+		interval.micros = RoundNumberToDivisor(interval.micros, Interval::DUCKDB_MICROS_PER_SEC);
 	}
 	return interval;
 }
@@ -360,11 +360,11 @@ struct EquiWidthBinsTimestamp {
 		// get the interval differences per component
 		// note: these can be negative (except for the largest non-zero difference)
 		interval_t interval_diff;
-		interval_diff.months = (max_year - min_year) * Interval::MONTHS_PER_YEAR + (max_month - min_month);
+		interval_diff.months = (max_year - min_year) * Interval::DUCKDB_MONTHS_PER_YEAR + (max_month - min_month);
 		interval_diff.days = max_day - min_day;
-		interval_diff.micros = (max_hour - min_hour) * Interval::MICROS_PER_HOUR +
-		                       (max_minute - min_minute) * Interval::MICROS_PER_MINUTE +
-		                       (max_sec - min_sec) * Interval::MICROS_PER_SEC + (max_micros - min_micros);
+		interval_diff.micros = (max_hour - min_hour) * Interval::DUCKDB_MICROS_PER_HOUR +
+		                       (max_minute - min_minute) * Interval::DUCKDB_MICROS_PER_MINUTE +
+		                       (max_sec - min_sec) * Interval::DUCKDB_MICROS_PER_SEC + (max_micros - min_micros);
 
 		double step_months = static_cast<double>(interval_diff.months) / static_cast<double>(bin_count);
 		double step_days = static_cast<double>(interval_diff.days) / static_cast<int32_t>(bin_count);
@@ -373,11 +373,11 @@ struct EquiWidthBinsTimestamp {
 		// becomes 6 days)
 		if (step_months > 0) {
 			double overflow_months = step_months - std::floor(step_months);
-			step_days += overflow_months * Interval::DAYS_PER_MONTH;
+			step_days += overflow_months * Interval::DUCKDB_DAYS_PER_MONTH;
 		}
 		if (step_days > 0) {
 			double overflow_days = step_days - std::floor(step_days);
-			step_micros += overflow_days * Interval::MICROS_PER_DAY;
+			step_micros += overflow_days * Interval::DUCKDB_MICROS_PER_DAY;
 		}
 		interval_t step;
 		step.months = static_cast<int32_t>(step_months);

--- a/src/function/scalar/strftime_format.cpp
+++ b/src/function/scalar/strftime_format.cpp
@@ -160,7 +160,7 @@ idx_t StrfTimeFormat::GetLength(date_t date, dtime_t time, int32_t utc_offset, c
 		int32_t data[8];
 		Date::Convert(date, data[0], data[1], data[2]);
 		Time::Convert(time, data[3], data[4], data[5], data[6]);
-		data[6] *= Interval::NANOS_PER_MICRO;
+		data[6] *= Interval::DUCKDB_NANOS_PER_MICRO;
 		data[7] = utc_offset;
 		return GetLength(date, data, tz_name);
 	}
@@ -356,17 +356,17 @@ char *StrfTimeFormat::WriteStandardSpecifier(StrTimeSpecifier specifier, int32_t
 		target = WritePadded(target, UnsafeNumericCast<uint32_t>(data[6]), 9);
 		break;
 	case StrTimeSpecifier::MICROSECOND_PADDED:
-		target = WritePadded(target, UnsafeNumericCast<uint32_t>(data[6] / Interval::NANOS_PER_MICRO), 6);
+		target = WritePadded(target, UnsafeNumericCast<uint32_t>(data[6] / Interval::DUCKDB_NANOS_PER_MICRO), 6);
 		break;
 	case StrTimeSpecifier::MILLISECOND_PADDED:
-		target = WritePadded3(target, UnsafeNumericCast<uint32_t>(data[6] / Interval::NANOS_PER_MSEC));
+		target = WritePadded3(target, UnsafeNumericCast<uint32_t>(data[6] / Interval::DUCKDB_NANOS_PER_MSEC));
 		break;
 	case StrTimeSpecifier::UTC_OFFSET: {
 		*target++ = (data[7] < 0) ? '-' : '+';
 
 		auto offset = abs(data[7]);
-		auto offset_hours = offset / Interval::MINS_PER_HOUR;
-		auto offset_minutes = offset % Interval::MINS_PER_HOUR;
+		auto offset_hours = offset / Interval::DUCKDB_MINS_PER_HOUR;
+		auto offset_minutes = offset % Interval::DUCKDB_MINS_PER_HOUR;
 		target = WritePadded2(target, UnsafeNumericCast<uint32_t>(offset_hours));
 		if (offset_minutes) {
 			*target++ = ':';
@@ -438,9 +438,9 @@ void StrfTimeFormat::FormatStringNS(date_t date, int32_t data[8], const char *tz
 }
 
 void StrfTimeFormat::FormatString(date_t date, int32_t data[8], const char *tz_name, char *target) {
-	data[6] *= Interval::NANOS_PER_MICRO;
+	data[6] *= Interval::DUCKDB_NANOS_PER_MICRO;
 	FormatStringNS(date, data, tz_name, target);
-	data[6] /= Interval::NANOS_PER_MICRO;
+	data[6] /= Interval::DUCKDB_NANOS_PER_MICRO;
 }
 
 void StrfTimeFormat::FormatString(date_t date, dtime_t time, char *target) {
@@ -679,7 +679,7 @@ string_t StrfTimeFormat::ConvertTimestampValue(const timestamp_t &input, Vector 
 		int32_t data[8]; // year, month, day, hour, min, sec, ns, offset
 		Date::Convert(date, data[0], data[1], data[2]);
 		Time::Convert(time, data[3], data[4], data[5], data[6]);
-		data[6] *= Interval::NANOS_PER_MICRO;
+		data[6] *= Interval::DUCKDB_NANOS_PER_MICRO;
 		data[7] = 0;
 		const char *tz_name = nullptr;
 
@@ -703,7 +703,7 @@ string_t StrfTimeFormat::ConvertTimestampValue(const timestamp_ns_t &input, Vect
 		int32_t data[8]; // year, month, day, hour, min, sec, ns, offset
 		Date::Convert(date, data[0], data[1], data[2]);
 		Time::Convert(time, data[3], data[4], data[5], data[6]);
-		data[6] *= Interval::NANOS_PER_MICRO;
+		data[6] *= Interval::DUCKDB_NANOS_PER_MICRO;
 		data[6] += nanos;
 		data[7] = 0;
 		const char *tz_name = nullptr;
@@ -1069,19 +1069,19 @@ bool StrpTimeFormat::Parse(const char *data, size_t size, ParseResult &result, b
 				result_data[5] = UnsafeNumericCast<int32_t>(number);
 				break;
 			case StrTimeSpecifier::NANOSECOND_PADDED:
-				D_ASSERT(number < Interval::NANOS_PER_SEC); // enforced by the length of the number
+				D_ASSERT(number < Interval::DUCKDB_NANOS_PER_SEC); // enforced by the length of the number
 				// nanoseconds
 				result_data[6] = UnsafeNumericCast<int32_t>(number);
 				break;
 			case StrTimeSpecifier::MICROSECOND_PADDED:
-				D_ASSERT(number < Interval::MICROS_PER_SEC); // enforced by the length of the number
+				D_ASSERT(number < Interval::DUCKDB_MICROS_PER_SEC); // enforced by the length of the number
 				// nanoseconds
-				result_data[6] = UnsafeNumericCast<int32_t>(number * Interval::NANOS_PER_MICRO);
+				result_data[6] = UnsafeNumericCast<int32_t>(number * Interval::DUCKDB_NANOS_PER_MICRO);
 				break;
 			case StrTimeSpecifier::MILLISECOND_PADDED:
-				D_ASSERT(number < Interval::MSECS_PER_SEC); // enforced by the length of the number
+				D_ASSERT(number < Interval::DUCKDB_MSECS_PER_SEC); // enforced by the length of the number
 				// nanoseconds
-				result_data[6] = UnsafeNumericCast<int32_t>(number * Interval::NANOS_PER_MSEC);
+				result_data[6] = UnsafeNumericCast<int32_t>(number * Interval::DUCKDB_NANOS_PER_MSEC);
 				break;
 			case StrTimeSpecifier::WEEK_NUMBER_PADDED_SUN_FIRST:
 			case StrTimeSpecifier::WEEK_NUMBER_PADDED_MON_FIRST:
@@ -1277,7 +1277,7 @@ bool StrpTimeFormat::Parse(const char *data, size_t size, ParseResult &result, b
 					error_position = pos;
 					return false;
 				}
-				result_data[7] = hour_offset * Interval::MINS_PER_HOUR + minute_offset;
+				result_data[7] = hour_offset * Interval::DUCKDB_MINS_PER_HOUR + minute_offset;
 				break;
 			}
 			case StrTimeSpecifier::TZ_NAME: {
@@ -1436,18 +1436,18 @@ bool StrpTimeFormat::ParseResult::TryToDate(date_t &result) {
 }
 
 int32_t StrpTimeFormat::ParseResult::GetMicros() const {
-	return UnsafeNumericCast<int32_t>((data[6] + Interval::NANOS_PER_MICRO / 2) / Interval::NANOS_PER_MICRO);
+	return UnsafeNumericCast<int32_t>((data[6] + Interval::DUCKDB_NANOS_PER_MICRO / 2) / Interval::DUCKDB_NANOS_PER_MICRO);
 }
 
 dtime_t StrpTimeFormat::ParseResult::ToTime() {
-	const auto hour_offset = data[7] / Interval::MINS_PER_HOUR;
-	const auto mins_offset = data[7] % Interval::MINS_PER_HOUR;
+	const auto hour_offset = data[7] / Interval::DUCKDB_MINS_PER_HOUR;
+	const auto mins_offset = data[7] % Interval::DUCKDB_MINS_PER_HOUR;
 	return Time::FromTime(data[3] - hour_offset, data[4] - mins_offset, data[5], GetMicros());
 }
 
 int64_t StrpTimeFormat::ParseResult::ToTimeNS() {
-	const int32_t hour_offset = data[7] / Interval::MINS_PER_HOUR;
-	const int32_t mins_offset = data[7] % Interval::MINS_PER_HOUR;
+	const int32_t hour_offset = data[7] / Interval::DUCKDB_MINS_PER_HOUR;
+	const int32_t mins_offset = data[7] % Interval::DUCKDB_MINS_PER_HOUR;
 	return Time::ToNanoTime(data[3] - hour_offset, data[4] - mins_offset, data[5], data[6]);
 }
 
@@ -1491,13 +1491,13 @@ timestamp_ns_t StrpTimeFormat::ParseResult::ToTimestampNS() {
 		} else if (special == date_t::ninfinity()) {
 			result.value = timestamp_t::ninfinity().value;
 		} else {
-			result.value = special.days * Interval::NANOS_PER_DAY;
+			result.value = special.days * Interval::DUCKDB_NANOS_PER_DAY;
 		}
 	} else {
 		// Don't use rounded µs
 		const auto date = ToDate();
 		const auto time = ToTimeNS();
-		if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(date.days, Interval::NANOS_PER_DAY,
+		if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(date.days, Interval::DUCKDB_NANOS_PER_DAY,
 		                                                               result.value)) {
 			throw ConversionException("Date out of nanosecond range: %d-%d-%d", data[0], data[1], data[2]);
 		}
@@ -1517,7 +1517,7 @@ bool StrpTimeFormat::ParseResult::TryToTimestampNS(timestamp_ns_t &result) {
 
 	// Don't use rounded µs
 	const auto time = ToTimeNS();
-	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(date.days, Interval::NANOS_PER_DAY, result.value)) {
+	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(date.days, Interval::DUCKDB_NANOS_PER_DAY, result.value)) {
 		return false;
 	}
 	if (!TryAddOperator::Operation<int64_t, int64_t, int64_t>(result.value, time, result.value)) {

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -532,7 +532,7 @@ static void IntervalConversionMonthDayNanos(Vector &vector, ArrowArray &array, c
 	    ArrowBufferData<ArrowInterval>(array, 1) + GetEffectiveOffset(array, parent_offset, scan_state, nested_offset);
 	for (idx_t row = 0; row < size; row++) {
 		tgt_ptr[row].days = src_ptr[row].days;
-		tgt_ptr[row].micros = src_ptr[row].nanoseconds / Interval::NANOS_PER_MICRO;
+		tgt_ptr[row].micros = src_ptr[row].nanoseconds / Interval::DUCKDB_NANOS_PER_MICRO;
 		tgt_ptr[row].months = src_ptr[row].months;
 	}
 }

--- a/src/include/duckdb/common/arrow/appender/scalar_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/scalar_data.hpp
@@ -31,7 +31,7 @@ struct ArrowIntervalConverter {
 		ArrowInterval result;
 		result.months = input.months;
 		result.days = input.days;
-		result.nanoseconds = input.micros * Interval::NANOS_PER_MICRO;
+		result.nanoseconds = input.micros * Interval::DUCKDB_NANOS_PER_MICRO;
 		return result;
 	}
 

--- a/src/include/duckdb/common/types/cast_helpers.hpp
+++ b/src/include/duckdb/common/types/cast_helpers.hpp
@@ -377,12 +377,12 @@ struct IntervalToStringCast {
 			} else {
 				micros = -micros;
 			}
-			int64_t hour = -(micros / Interval::MICROS_PER_HOUR);
-			micros += hour * Interval::MICROS_PER_HOUR;
-			int64_t min = -(micros / Interval::MICROS_PER_MINUTE);
-			micros += min * Interval::MICROS_PER_MINUTE;
-			int64_t sec = -(micros / Interval::MICROS_PER_SEC);
-			micros += sec * Interval::MICROS_PER_SEC;
+			int64_t hour = -(micros / Interval::DUCKDB_MICROS_PER_HOUR);
+			micros += hour * Interval::DUCKDB_MICROS_PER_HOUR;
+			int64_t min = -(micros / Interval::DUCKDB_MICROS_PER_MINUTE);
+			micros += min * Interval::DUCKDB_MICROS_PER_MINUTE;
+			int64_t sec = -(micros / Interval::DUCKDB_MICROS_PER_SEC);
+			micros += sec * Interval::DUCKDB_MICROS_PER_SEC;
 			micros = -micros;
 
 			if (hour < 10) {

--- a/src/include/duckdb/common/types/interval.hpp
+++ b/src/include/duckdb/common/types/interval.hpp
@@ -86,38 +86,38 @@ struct interval_t { // NOLINT
 //! type.
 class Interval {
 public:
-	static constexpr const int32_t MONTHS_PER_MILLENIUM = 12000;
-	static constexpr const int32_t MONTHS_PER_CENTURY = 1200;
-	static constexpr const int32_t MONTHS_PER_DECADE = 120;
-	static constexpr const int32_t MONTHS_PER_YEAR = 12;
-	static constexpr const int32_t MONTHS_PER_QUARTER = 3;
-	static constexpr const int32_t DAYS_PER_WEEK = 7;
+	static constexpr const int32_t DUCKDB_MONTHS_PER_MILLENIUM = 12000;
+	static constexpr const int32_t DUCKDB_MONTHS_PER_CENTURY = 1200;
+	static constexpr const int32_t DUCKDB_MONTHS_PER_DECADE = 120;
+	static constexpr const int32_t DUCKDB_MONTHS_PER_YEAR = 12;
+	static constexpr const int32_t DUCKDB_MONTHS_PER_QUARTER = 3;
+	static constexpr const int32_t DUCKDB_DAYS_PER_WEEK = 7;
 	//! only used for interval comparison/ordering purposes, in which case a month counts as 30 days
-	static constexpr const int64_t DAYS_PER_MONTH = 30;
-	static constexpr const int64_t DAYS_PER_YEAR = 365;
-	static constexpr const int64_t MSECS_PER_SEC = 1000;
-	static constexpr const int32_t SECS_PER_MINUTE = 60;
-	static constexpr const int32_t MINS_PER_HOUR = 60;
-	static constexpr const int32_t HOURS_PER_DAY = 24;
-	static constexpr const int32_t SECS_PER_HOUR = SECS_PER_MINUTE * MINS_PER_HOUR;
-	static constexpr const int32_t SECS_PER_DAY = SECS_PER_HOUR * HOURS_PER_DAY;
-	static constexpr const int32_t SECS_PER_WEEK = SECS_PER_DAY * DAYS_PER_WEEK;
+	static constexpr const int64_t DUCKDB_DAYS_PER_MONTH = 30;
+	static constexpr const int64_t DUCKDB_DAYS_PER_YEAR = 365;
+	static constexpr const int64_t DUCKDB_MSECS_PER_SEC = 1000;
+	static constexpr const int32_t DUCKDB_SECS_PER_MINUTE = 60;
+	static constexpr const int32_t DUCKDB_MINS_PER_HOUR = 60;
+	static constexpr const int32_t DUCKDB_HOURS_PER_DAY = 24;
+	static constexpr const int32_t DUCKDB_SECS_PER_HOUR = DUCKDB_SECS_PER_MINUTE * DUCKDB_MINS_PER_HOUR;
+	static constexpr const int32_t DUCKDB_SECS_PER_DAY = DUCKDB_SECS_PER_HOUR * DUCKDB_HOURS_PER_DAY;
+	static constexpr const int32_t DUCKDB_SECS_PER_WEEK = DUCKDB_SECS_PER_DAY * DUCKDB_DAYS_PER_WEEK;
 
-	static constexpr const int64_t MICROS_PER_MSEC = 1000;
-	static constexpr const int64_t MICROS_PER_SEC = MICROS_PER_MSEC * MSECS_PER_SEC;
-	static constexpr const int64_t MICROS_PER_MINUTE = MICROS_PER_SEC * SECS_PER_MINUTE;
-	static constexpr const int64_t MICROS_PER_HOUR = MICROS_PER_MINUTE * MINS_PER_HOUR;
-	static constexpr const int64_t MICROS_PER_DAY = MICROS_PER_HOUR * HOURS_PER_DAY;
-	static constexpr const int64_t MICROS_PER_WEEK = MICROS_PER_DAY * DAYS_PER_WEEK;
-	static constexpr const int64_t MICROS_PER_MONTH = MICROS_PER_DAY * DAYS_PER_MONTH;
+	static constexpr const int64_t DUCKDB_MICROS_PER_MSEC = 1000;
+	static constexpr const int64_t DUCKDB_MICROS_PER_SEC = DUCKDB_MICROS_PER_MSEC * DUCKDB_MSECS_PER_SEC;
+	static constexpr const int64_t DUCKDB_MICROS_PER_MINUTE = DUCKDB_MICROS_PER_SEC * DUCKDB_SECS_PER_MINUTE;
+	static constexpr const int64_t DUCKDB_MICROS_PER_HOUR = DUCKDB_MICROS_PER_MINUTE * DUCKDB_MINS_PER_HOUR;
+	static constexpr const int64_t DUCKDB_MICROS_PER_DAY = DUCKDB_MICROS_PER_HOUR * DUCKDB_HOURS_PER_DAY;
+	static constexpr const int64_t DUCKDB_MICROS_PER_WEEK = DUCKDB_MICROS_PER_DAY * DUCKDB_DAYS_PER_WEEK;
+	static constexpr const int64_t DUCKDB_MICROS_PER_MONTH = DUCKDB_MICROS_PER_DAY * DUCKDB_DAYS_PER_MONTH;
 
-	static constexpr const int64_t NANOS_PER_MICRO = 1000;
-	static constexpr const int64_t NANOS_PER_MSEC = NANOS_PER_MICRO * MICROS_PER_MSEC;
-	static constexpr const int64_t NANOS_PER_SEC = NANOS_PER_MSEC * MSECS_PER_SEC;
-	static constexpr const int64_t NANOS_PER_MINUTE = NANOS_PER_SEC * SECS_PER_MINUTE;
-	static constexpr const int64_t NANOS_PER_HOUR = NANOS_PER_MINUTE * MINS_PER_HOUR;
-	static constexpr const int64_t NANOS_PER_DAY = NANOS_PER_HOUR * HOURS_PER_DAY;
-	static constexpr const int64_t NANOS_PER_WEEK = NANOS_PER_DAY * DAYS_PER_WEEK;
+	static constexpr const int64_t DUCKDB_NANOS_PER_MICRO = 1000;
+	static constexpr const int64_t DUCKDB_NANOS_PER_MSEC = DUCKDB_NANOS_PER_MICRO * DUCKDB_MICROS_PER_MSEC;
+	static constexpr const int64_t DUCKDB_NANOS_PER_SEC = DUCKDB_NANOS_PER_MSEC * DUCKDB_MSECS_PER_SEC;
+	static constexpr const int64_t DUCKDB_NANOS_PER_MINUTE = DUCKDB_NANOS_PER_SEC * DUCKDB_SECS_PER_MINUTE;
+	static constexpr const int64_t DUCKDB_NANOS_PER_HOUR = DUCKDB_NANOS_PER_MINUTE * DUCKDB_MINS_PER_HOUR;
+	static constexpr const int64_t DUCKDB_NANOS_PER_DAY = DUCKDB_NANOS_PER_HOUR * DUCKDB_HOURS_PER_DAY;
+	static constexpr const int64_t DUCKDB_NANOS_PER_WEEK = DUCKDB_NANOS_PER_DAY * DUCKDB_DAYS_PER_WEEK;
 
 public:
 	//! Convert a string to an interval object
@@ -167,13 +167,13 @@ public:
 };
 void interval_t::Normalize(int64_t &months, int64_t &days, int64_t &micros) const {
 	auto input = *this;
-	int64_t extra_months_d = input.days / Interval::DAYS_PER_MONTH;
-	int64_t extra_months_micros = input.micros / Interval::MICROS_PER_MONTH;
-	input.days -= UnsafeNumericCast<int32_t>(extra_months_d * Interval::DAYS_PER_MONTH);
-	input.micros -= extra_months_micros * Interval::MICROS_PER_MONTH;
+	int64_t extra_months_d = input.days / Interval::DUCKDB_DAYS_PER_MONTH;
+	int64_t extra_months_micros = input.micros / Interval::DUCKDB_MICROS_PER_MONTH;
+	input.days -= UnsafeNumericCast<int32_t>(extra_months_d * Interval::DUCKDB_DAYS_PER_MONTH);
+	input.micros -= extra_months_micros * Interval::DUCKDB_MICROS_PER_MONTH;
 
-	int64_t extra_days_micros = input.micros / Interval::MICROS_PER_DAY;
-	input.micros -= extra_days_micros * Interval::MICROS_PER_DAY;
+	int64_t extra_days_micros = input.micros / Interval::DUCKDB_MICROS_PER_DAY;
+	input.micros -= extra_days_micros * Interval::DUCKDB_MICROS_PER_DAY;
 
 	months = input.months + extra_months_d + extra_months_micros;
 	days = input.days + extra_days_micros;

--- a/src/include/duckdb/core_functions/to_interval.hpp
+++ b/src/include/duckdb/core_functions/to_interval.hpp
@@ -19,7 +19,7 @@ struct ToSecondsOperator {
 		interval_t result;
 		result.months = 0;
 		result.days = 0;
-		if (!TryMultiplyOperator::Operation<TA, int64_t, int64_t>(input, Interval::MICROS_PER_SEC, result.micros)) {
+		if (!TryMultiplyOperator::Operation<TA, int64_t, int64_t>(input, Interval::DUCKDB_MICROS_PER_SEC, result.micros)) {
 			throw OutOfRangeException("Interval value %s seconds out of range", NumericHelper::ToString(input));
 		}
 		return result;


### PR DESCRIPTION
Rename constants in `src/include/duckdb/common/types/interval.hpp` to avoid name conflicts with WutongDB macros.